### PR TITLE
Unify handling of newlines following { among if/else

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -1000,14 +1000,8 @@ static void newlines_do_else(chunk_t *start, argval_t nl_opt)
       else
       {
          newline_iarf_pair(start, next, nl_opt);
-         if ((nl_opt & AV_ADD) != 0)
-         {
-            tmp = chunk_get_next_nc(next);
-            if ((tmp != NULL) && !chunk_is_newline(tmp))
-            {
-               newline_add_between(next, tmp);
-            }
-         }
+
+         newline_add_between(next, chunk_get_next_ncnl(next));
       }
    }
 }

--- a/tests/c.test
+++ b/tests/c.test
@@ -39,6 +39,7 @@
 00055  cgal.cfg                c/braces-2.c
 00056  brace-remove-all.cfg    c/brace-remove3.c
 00057  if_chain.cfg            c/brace-remove3.c
+00058  brace-kr-nobr.cfg       c/if_chain.c
 
 00060  ben.cfg                 c/braces-2.c
 00061  ben.cfg                 c/braces-3.c

--- a/tests/config/brace-kr-nobr.cfg
+++ b/tests/config/brace-kr-nobr.cfg
@@ -1,0 +1,42 @@
+#
+#  K&R style
+#
+
+indent_with_tabs		= 1		# 1=indent to level only, 2=indent with tabs
+input_tab_size			= 8		# original tab size
+output_tab_size			= 8		# new tab size
+indent_columns			= output_tab_size
+
+# brace placement
+nl_assign_brace			= remove	# "= {" vs "= \n {"
+nl_enum_brace			= remove	# "enum {" vs "enum \n {"
+nl_union_brace			= remove	# "union {" vs "union \n {"
+nl_struct_brace			= remove	# "struct {" vs "struct \n {"
+nl_do_brace			= remove	# "do {" vs "do \n {"
+nl_if_brace			= remove	# "if () {" vs "if () \n {"
+nl_for_brace			= remove	# "for () {" vs "for () \n {"
+nl_else_brace			= remove	# "else {" vs "else \n {"
+nl_while_brace			= remove	# "while () {" vs "while () \n {"
+nl_switch_brace			= remove	# "switch () {" vs "switch () \n {"
+nl_fcall_brace			= add		# "foo() {" vs "foo()\n{"
+nl_fdef_brace			= add		# "int foo() {" vs "int foo()\n{"
+nl_brace_while			= remove
+nl_brace_else			= remove
+
+# spaces around braces
+sp_before_sparen		= force		# "if (" vs "if("
+sp_after_sparen			= force		# "if () {" vs "if (){"
+sp_assign			= add
+sp_else_brace			= force
+
+# nl_squeeze_ifdef		= TRUE
+# nl_func_var_def_blk		= 1
+# nl_before_case			= 1
+# nl_after_return			= TRUE
+
+nl_after_brace_open           = false
+nl_remove_extra_newlines      = 2
+mod_full_brace_do             = add
+mod_full_brace_for            = add
+mod_full_brace_if             = add
+

--- a/tests/output/c/00058-if_chain.c
+++ b/tests/output/c/00058-if_chain.c
@@ -1,0 +1,69 @@
+void foo(void)
+{
+	if (cond_a) {
+		fcn_a(); fcn_b();
+	} else {
+		fcn_c();
+	} if (cond_b) {
+		fcn_d();
+	} else {
+		fcn_e();
+	} if (cond_c) {
+		fcn_f(); fcn_g();
+	} else {
+		fcn_h();
+	} if (cond_d) {
+		fcn_i();
+	} else {
+		fcn_j(); fcn_k();
+	} if (cond_e) {
+		fcn_l();
+	} else {
+		fcn_m();
+	} if (cond_f) {
+		fcn_n();
+	} else if (cond_g) {
+		fcn_o(); while (cond_g) {
+			fcn_p();
+		}
+	} else if (cond_h) {
+		while (cond_i) {
+			fcn_q(); fcn_r();
+		}
+	} else {
+		fcn_s();
+	}
+}
+/* this next bit test whether vbraces can be successfully converted
+ * when the closing brace is in an #ifdef.
+ * Note that the author should have braced the code to begin with.
+ */
+void bar(void)
+{
+	if (jiffies >= hw_priv->Counter[ port ].time) {
+		hw_priv->Counter[ port ].fRead = 1; if (port == MAIN_PORT) {
+			hw_priv->Counter[ MAIN_PORT ].time = jiffies + HZ * 6;
+		} else {
+			hw_priv->Counter[ port ].time =
+
+#ifdef SOME_DEFINE
+			        hw_priv->Counter[ port - 1 ].time + HZ * 2;
+		}
+
+#else /* ifdef SOME_DEFINE */
+			        hw_priv->Counter[ MAIN_PORT ].time + HZ * 2;
+#endif /* ifdef SOME_DEFINE */
+	}
+}
+void funct(int v1, int v2, int v3)
+{
+	if ( v1 ) {
+		if ( v2 ) {
+			f1();
+		}
+	}else {
+		if ( v3 ) {
+			f2();
+		}
+	}
+}


### PR DESCRIPTION
**Problem**:

For various reasons, I want to

 - have `nl_remove_extra_newlines = 2`
 - have `nl_after_brace_open = false`

With the attached config file (see below) and the sample program

    int main(void){ if (1 == 1) { return 0; } else { return 1; } }

I expect output

    int
    main(void)
    {
            if (1 == 1) {
                    return 0;
            } else {
                    return 1;
            }
    }

Instead, I get


    int
    main(void)
    {
            if (1 == 1) {
                    return 0;
            } else { return 1;
            }
    }

**Proposed solution**:

This is handled by `newlines.cpp:2092`, which calls
`newlines_do_else(pc, cpd.settings[UO_nl_else_brace].a)` My config has
`nl_brace_else` set to `remove`. Setting it to `force` gives

    int
    main(void)
    {
            if (1 == 1) {
                    return 0;
            } else
            {
                    return 1;
            }
    }

which is also not what I want (I prefer K&R to Allman). The reason I
am happy with handling of `if` (and `else if` and `while` and...) is
that their newlines are added unconditionally by
`newline_add_between(brace_open, chunk_get_next_ncnl(brace_open))` in
this situation, from `newlines_if_for_while_switch`.

Therefore, this patch replaces the brace-handling logic of
`newlines_do_else` with the corresponding parts from
`newlines_if_for_while_switch`.

**What does it break?**:

Nothing, that I can tell.  All tests pass as expected.  It does fix
issue #311, I believe.


-----
Configuration file that reproduces this issue

----

    # Uncrustify 0.61
    newlines                                  = auto
    input_tab_size                            = 8
    output_tab_size                           = 8
    string_escape_char                        = 92
    string_escape_char2                       = 0
    tok_split_gte                             = false
    utf8_bom                                  = ignore
    utf8_byte                                 = false
    utf8_force                                = false
    indent_columns                            = 8
    indent_continue                           = 0
    indent_with_tabs                          = 0
    indent_cmt_with_tabs                      = false
    indent_align_string                       = true
    indent_xml_string                         = 0
    indent_brace                              = 0
    indent_braces                             = false
    indent_braces_no_func                     = false
    indent_braces_no_class                    = false
    indent_braces_no_struct                   = false
    indent_brace_parent                       = false
    indent_paren_open_brace                   = false
    indent_namespace                          = false
    indent_namespace_single_indent            = false
    indent_namespace_level                    = 0
    indent_namespace_limit                    = 0
    indent_extern                             = false
    indent_class                              = false
    indent_class_colon                        = false
    indent_constr_colon                       = false
    indent_ctor_init_leading                  = 2
    indent_ctor_init                          = 0
    indent_else_if                            = false
    indent_var_def_blk                        = 0
    indent_var_def_cont                       = false
    indent_func_def_force_col1                = false
    indent_func_call_param                    = false
    indent_func_def_param                     = false
    indent_func_proto_param                   = false
    indent_func_class_param                   = false
    indent_func_ctor_var_param                = false
    indent_template_param                     = false
    indent_func_param_double                  = false
    indent_func_const                         = 0
    indent_func_throw                         = 0
    indent_member                             = 0
    indent_sing_line_comments                 = 0
    indent_relative_single_line_comments      = false
    indent_switch_case                        = 0
    indent_case_shift                         = 0
    indent_case_brace                         = 0
    indent_col1_comment                       = false
    indent_label                              = 1
    indent_access_spec                        = 1
    indent_access_spec_body                   = false
    indent_paren_nl                           = false
    indent_paren_close                        = 0
    indent_comma_paren                        = false
    indent_bool_paren                         = false
    indent_first_bool_expr                    = false
    indent_square_nl                          = false
    indent_preserve_sql                       = false
    indent_align_assign                       = true
    indent_oc_block                           = false
    indent_oc_block_msg                       = 0
    indent_oc_msg_colon                       = 0
    indent_oc_msg_prioritize_first_colon      = true
    indent_oc_block_msg_xcode_style           = false
    indent_oc_block_msg_from_keyword          = false
    indent_oc_block_msg_from_colon            = false
    indent_oc_block_msg_from_caret            = false
    indent_oc_block_msg_from_brace            = false
    sp_arith                                  = force
    sp_assign                                 = force
    sp_cpp_lambda_assign                      = ignore
    sp_cpp_lambda_paren                       = ignore
    sp_assign_default                         = ignore
    sp_before_assign                          = ignore
    sp_after_assign                           = ignore
    sp_enum_assign                            = ignore
    sp_enum_before_assign                     = ignore
    sp_enum_after_assign                      = ignore
    sp_pp_concat                              = add
    sp_pp_stringify                           = ignore
    sp_before_pp_stringify                    = ignore
    sp_bool                                   = force
    sp_compare                                = force
    sp_inside_paren                           = remove
    sp_paren_paren                            = remove
    sp_cparen_oparen                          = ignore
    sp_balance_nested_parens                  = false
    sp_paren_brace                            = force
    sp_before_ptr_star                        = force
    sp_before_unnamed_ptr_star                = force
    sp_between_ptr_star                       = remove
    sp_after_ptr_star                         = ignore
    sp_after_ptr_star_qualifier               = force
    sp_after_ptr_star_func                    = ignore
    sp_ptr_star_paren                         = ignore
    sp_before_ptr_star_func                   = ignore
    sp_before_byref                           = ignore
    sp_before_unnamed_byref                   = ignore
    sp_after_byref                            = ignore
    sp_after_byref_func                       = ignore
    sp_before_byref_func                      = ignore
    sp_after_type                             = force
    sp_before_template_paren                  = ignore
    sp_template_angle                         = ignore
    sp_before_angle                           = ignore
    sp_inside_angle                           = ignore
    sp_after_angle                            = ignore
    sp_angle_paren                            = ignore
    sp_angle_word                             = ignore
    sp_angle_shift                            = add
    sp_permit_cpp11_shift                     = false
    sp_before_sparen                          = force
    sp_inside_sparen                          = remove
    sp_inside_sparen_close                    = ignore
    sp_inside_sparen_open                     = ignore
    sp_after_sparen                           = force
    sp_sparen_brace                           = force
    sp_invariant_paren                        = ignore
    sp_after_invariant_paren                  = ignore
    sp_special_semi                           = ignore
    sp_before_semi                            = remove
    sp_before_semi_for                        = ignore
    sp_before_semi_for_empty                  = ignore
    sp_after_semi                             = add
    sp_after_semi_for                         = force
    sp_after_semi_for_empty                   = ignore
    sp_before_square                          = remove
    sp_before_squares                         = remove
    sp_inside_square                          = remove
    sp_after_comma                            = force
    sp_before_comma                           = remove
    sp_paren_comma                            = force
    sp_before_ellipsis                        = force
    sp_after_class_colon                      = ignore
    sp_before_class_colon                     = ignore
    sp_before_case_colon                      = remove
    sp_after_operator                         = ignore
    sp_after_operator_sym                     = ignore
    sp_after_cast                             = force
    sp_inside_paren_cast                      = remove
    sp_cpp_cast_paren                         = ignore
    sp_sizeof_paren                           = ignore
    sp_after_tag                              = ignore
    sp_inside_braces_enum                     = force
    sp_inside_braces_struct                   = force
    sp_inside_braces                          = force
    sp_inside_braces_empty                    = ignore
    sp_type_func                              = force
    sp_func_proto_paren                       = ignore
    sp_func_def_paren                         = ignore
    sp_inside_fparens                         = remove
    sp_inside_fparen                          = remove
    sp_inside_tparen                          = remove
    sp_after_tparen_close                     = remove
    sp_square_fparen                          = remove
    sp_fparen_brace                           = force
    sp_func_call_paren                        = remove
    sp_func_call_paren_empty                  = remove
    sp_func_call_user_paren                   = remove
    sp_func_class_paren                       = remove
    sp_return_paren                           = force
    sp_attribute_paren                        = force
    sp_defined_paren                          = force
    sp_throw_paren                            = force
    sp_after_throw                            = force
    sp_catch_paren                            = force
    sp_version_paren                          = ignore
    sp_scope_paren                            = ignore
    sp_macro                                  = ignore
    sp_macro_func                             = ignore
    sp_else_brace                             = force
    sp_brace_else                             = force
    sp_brace_typedef                          = force
    sp_catch_brace                            = force
    sp_brace_catch                            = force
    sp_finally_brace                          = force
    sp_brace_finally                          = force
    sp_try_brace                              = force
    sp_getset_brace                           = ignore
    sp_word_brace                             = add
    sp_word_brace_ns                          = add
    sp_before_dc                              = ignore
    sp_after_dc                               = ignore
    sp_d_array_colon                          = ignore
    sp_not                                    = remove
    sp_inv                                    = remove
    sp_addr                                   = remove
    sp_member                                 = remove
    sp_deref                                  = remove
    sp_sign                                   = remove
    sp_incdec                                 = remove
    sp_before_nl_cont                         = force
    sp_after_oc_scope                         = ignore
    sp_after_oc_colon                         = ignore
    sp_before_oc_colon                        = ignore
    sp_after_oc_dict_colon                    = ignore
    sp_before_oc_dict_colon                   = ignore
    sp_after_send_oc_colon                    = ignore
    sp_before_send_oc_colon                   = ignore
    sp_after_oc_type                          = ignore
    sp_after_oc_return_type                   = ignore
    sp_after_oc_at_sel                        = ignore
    sp_after_oc_at_sel_parens                 = ignore
    sp_inside_oc_at_sel_parens                = ignore
    sp_before_oc_block_caret                  = ignore
    sp_after_oc_block_caret                   = ignore
    sp_after_oc_msg_receiver                  = ignore
    sp_after_oc_property                      = ignore
    sp_cond_colon                             = force
    sp_cond_colon_before                      = ignore
    sp_cond_colon_after                       = ignore
    sp_cond_question                          = force
    sp_cond_question_before                   = ignore
    sp_cond_question_after                    = ignore
    sp_cond_ternary_short                     = ignore
    sp_case_label                             = force
    sp_range                                  = ignore
    sp_after_for_colon                        = force
    sp_before_for_colon                       = force
    sp_extern_paren                           = ignore
    sp_cmt_cpp_start                          = ignore
    sp_endif_cmt                              = ignore
    sp_after_new                              = ignore
    sp_before_tr_emb_cmt                      = ignore
    sp_num_before_tr_emb_cmt                  = 0
    sp_annotation_paren                       = ignore
    align_keep_tabs                           = false
    align_with_tabs                           = false
    align_on_tabstop                          = false
    align_number_left                         = false
    align_keep_extra_space                    = false
    align_func_params                         = false
    align_same_func_call_params               = false
    align_var_def_span                        = 0
    align_var_def_star_style                  = 0
    align_var_def_amp_style                   = 0
    align_var_def_thresh                      = 0
    align_var_def_gap                         = 0
    align_var_def_colon                       = false
    align_var_def_attribute                   = false
    align_var_def_inline                      = false
    align_assign_span                         = 0
    align_assign_thresh                       = 0
    align_enum_equ_span                       = 0
    align_enum_equ_thresh                     = 0
    align_var_struct_span                     = 0
    align_var_struct_thresh                   = 0
    align_var_struct_gap                      = 0
    align_struct_init_span                    = 0
    align_typedef_gap                         = 0
    align_typedef_span                        = 0
    align_typedef_func                        = 0
    align_typedef_star_style                  = 0
    align_typedef_amp_style                   = 0
    align_right_cmt_span                      = 3
    align_right_cmt_mix                       = false
    align_right_cmt_gap                       = 0
    align_right_cmt_at_col                    = 0
    align_func_proto_span                     = 0
    align_func_proto_gap                      = 0
    align_on_operator                         = false
    align_mix_var_proto                       = false
    align_single_line_func                    = false
    align_single_line_brace                   = false
    align_single_line_brace_gap               = 0
    align_oc_msg_spec_span                    = 0
    align_nl_cont                             = false
    align_pp_define_together                  = false
    align_pp_define_gap                       = 0
    align_pp_define_span                      = 0
    align_left_shift                          = true
    align_oc_msg_colon_span                   = 0
    align_oc_msg_colon_first                  = false
    align_oc_decl_colon                       = false
    nl_collapse_empty_body                    = false
    nl_assign_leave_one_liners                = true
    nl_class_leave_one_liners                 = false
    nl_enum_leave_one_liners                  = true
    nl_getset_leave_one_liners                = false
    nl_func_leave_one_liners                  = false
    nl_cpp_lambda_leave_one_liners            = false
    nl_if_leave_one_liners                    = false
    nl_oc_msg_leave_one_liner                 = false
    nl_start_of_file                          = remove
    nl_start_of_file_min                      = 0
    nl_end_of_file                            = remove
    nl_end_of_file_min                        = 0
    nl_assign_brace                           = remove
    nl_assign_square                          = ignore
    nl_after_square_assign                    = ignore
    nl_func_var_def_blk                       = 1
    nl_typedef_blk_start                      = 0
    nl_typedef_blk_end                        = 0
    nl_typedef_blk_in                         = 0
    nl_var_def_blk_start                      = 0
    nl_var_def_blk_end                        = 0
    nl_var_def_blk_in                         = 0
    nl_fcall_brace                            = remove
    nl_enum_brace                             = remove
    nl_struct_brace                           = remove
    nl_union_brace                            = remove
    nl_if_brace                               = remove
    nl_brace_else                             = remove
    nl_elseif_brace                           = ignore
    nl_else_brace                             = remove
    nl_else_if                                = remove
    nl_brace_finally                          = ignore
    nl_finally_brace                          = ignore
    nl_try_brace                              = ignore
    nl_getset_brace                           = ignore
    nl_for_brace                              = remove
    nl_catch_brace                            = ignore
    nl_brace_catch                            = ignore
    nl_while_brace                            = remove
    nl_scope_brace                            = ignore
    nl_unittest_brace                         = ignore
    nl_version_brace                          = ignore
    nl_using_brace                            = ignore
    nl_brace_brace                            = ignore
    nl_do_brace                               = remove
    nl_brace_while                            = remove
    nl_switch_brace                           = remove
    nl_multi_line_cond                        = false
    nl_multi_line_define                      = false
    nl_before_case                            = false
    nl_before_throw                           = ignore
    nl_after_case                             = true
    nl_case_colon_brace                       = ignore
    nl_namespace_brace                        = ignore
    nl_template_class                         = ignore
    nl_class_brace                            = ignore
    nl_class_init_args                        = force
    nl_func_type_name                         = force
    nl_func_type_name_class                   = ignore
    nl_func_scope_name                        = ignore
    nl_func_proto_type_name                   = force
    nl_func_paren                             = ignore
    nl_func_def_paren                         = ignore
    nl_func_decl_start                        = ignore
    nl_func_def_start                         = ignore
    nl_func_decl_start_single                 = ignore
    nl_func_def_start_single                  = ignore
    nl_func_decl_args                         = ignore
    nl_func_def_args                          = force
    nl_func_decl_end                          = ignore
    nl_func_def_end                           = ignore
    nl_func_decl_end_single                   = ignore
    nl_func_def_end_single                    = ignore
    nl_func_decl_empty                        = ignore
    nl_func_def_empty                         = ignore
    nl_oc_msg_args                            = false
    nl_fdef_brace                             = add
    nl_cpp_ldef_brace                         = ignore
    nl_return_expr                            = ignore
    nl_after_semicolon                        = true
    nl_after_brace_open                       = false
    nl_after_brace_open_cmt                   = false
    nl_after_vbrace_open                      = true
    nl_after_vbrace_open_empty                = false
    nl_after_brace_close                      = true
    nl_after_vbrace_close                     = true
    nl_brace_struct_var                       = ignore
    nl_define_macro                           = false
    nl_squeeze_ifdef                          = false
    nl_before_if                              = force
    nl_after_if                               = force
    nl_before_for                             = force
    nl_after_for                              = force
    nl_before_while                           = force
    nl_after_while                            = force
    nl_before_switch                          = force
    nl_after_switch                           = force
    nl_before_do                              = force
    nl_after_do                               = force
    nl_ds_struct_enum_cmt                     = false
    nl_ds_struct_enum_close_brace             = false
    nl_class_colon                            = ignore
    nl_create_if_one_liner                    = false
    nl_create_for_one_liner                   = false
    nl_create_while_one_liner                 = false
    pos_arith                                 = ignore
    pos_assign                                = ignore
    pos_bool                                  = trail_force
    pos_compare                               = ignore
    pos_conditional                           = ignore
    pos_comma                                 = trail
    pos_class_comma                           = trail
    pos_class_colon                           = ignore
    code_width                                = 80
    ls_for_split_full                         = true
    ls_func_split_full                        = true
    ls_code_width                             = false
    nl_max                                    = 2
    nl_after_func_proto                       = 0
    nl_after_func_proto_group                 = 0
    nl_after_func_body                        = 0
    nl_after_func_body_class                  = 0
    nl_after_func_body_one_liner              = 0
    nl_before_block_comment                   = 0
    nl_before_c_comment                       = 2
    nl_before_cpp_comment                     = 0
    nl_after_multiline_comment                = false
    nl_after_struct                           = 0
    nl_after_class                            = 0
    nl_before_access_spec                     = 0
    nl_after_access_spec                      = 0
    nl_comment_func_def                       = 0
    nl_after_try_catch_finally                = 0
    nl_around_cs_property                     = 0
    nl_between_get_set                        = 0
    nl_property_brace                         = ignore
    eat_blanks_after_open_brace               = false
    eat_blanks_before_close_brace             = false
    nl_remove_extra_newlines                  = 2
    nl_before_return                          = true
    nl_after_return                           = false
    nl_after_annotation                       = ignore
    nl_between_annotation                     = ignore
    mod_full_brace_do                         = force
    mod_full_brace_for                        = force
    mod_full_brace_function                   = force
    mod_full_brace_if                         = force
    mod_full_brace_if_chain                   = force
    mod_full_brace_nl                         = 3
    mod_full_brace_while                      = force
    mod_full_brace_using                      = ignore
    mod_paren_on_return                       = remove
    mod_pawn_semicolon                        = false
    mod_full_paren_if_bool                    = false
    mod_remove_extra_semicolon                = true
    mod_add_long_function_closebrace_comment  = 0
    mod_add_long_namespace_closebrace_comment = 0
    mod_add_long_switch_closebrace_comment    = 0
    mod_add_long_ifdef_endif_comment          = 0
    mod_add_long_ifdef_else_comment           = 0
    mod_sort_import                           = false
    mod_sort_using                            = false
    mod_sort_include                          = true
    mod_move_case_break                       = false
    mod_case_brace                            = ignore
    mod_remove_empty_return                   = false
    cmt_width                                 = 0
    cmt_reflow_mode                           = 0
    cmt_indent_multi                          = true
    cmt_c_group                               = false
    cmt_c_nl_start                            = false
    cmt_c_nl_end                              = false
    cmt_cpp_group                             = false
    cmt_cpp_nl_start                          = false
    cmt_cpp_nl_end                            = false
    cmt_cpp_to_c                              = false
    cmt_star_cont                             = false
    cmt_sp_before_star_cont                   = 0
    cmt_sp_after_star_cont                    = 0
    cmt_multi_check_last                      = true
    cmt_insert_file_header                    = ""
    cmt_insert_file_footer                    = ""
    cmt_insert_func_header                    = ""
    cmt_insert_class_header                   = ""
    cmt_insert_oc_msg_header                  = ""
    cmt_insert_before_preproc                 = false
    pp_indent                                 = ignore
    pp_indent_at_level                        = false
    pp_indent_count                           = 1
    pp_space                                  = ignore
    pp_space_count                            = 0
    pp_indent_region                          = 0
    pp_region_indent_code                     = false
    pp_indent_if                              = 0
    pp_if_indent_code                         = false
    pp_define_at_level                        = false
    
