### PR TITLE
Fix some mistakes in the documentation

### DIFF
--- a/documentation/htdocs/config.txt
+++ b/documentation/htdocs/config.txt
@@ -393,7 +393,7 @@ sp_inside_sparen_close                    { Ignore, Add, Remove, Force }
   Add or remove space before if-condition ')'. Overrides sp_inside_sparen.
 
 sp_inside_sparen_open                     { Ignore, Add, Remove, Force }
-  Add or remove space before if-condition '('. Overrides sp_inside_sparen.
+  Add or remove space after if-condition '('. Overrides sp_inside_sparen.
 
 sp_after_sparen                           { Ignore, Add, Remove, Force }
   Add or remove space after ')' of 'if', 'for', 'switch', and 'while'

--- a/documentation/htdocs/default.cfg
+++ b/documentation/htdocs/default.cfg
@@ -402,7 +402,7 @@ sp_inside_sparen                          = ignore   # ignore/add/remove/force
 # Add or remove space before if-condition ')'. Overrides sp_inside_sparen.
 sp_inside_sparen_close                    = ignore   # ignore/add/remove/force
 
-# Add or remove space before if-condition '('. Overrides sp_inside_sparen.
+# Add or remove space after if-condition '('. Overrides sp_inside_sparen.
 sp_inside_sparen_open                     = ignore   # ignore/add/remove/force
 
 # Add or remove space after ')' of 'if', 'for', 'switch', and 'while'

--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -402,7 +402,7 @@ sp_inside_sparen                          = ignore   # ignore/add/remove/force
 # Add or remove space before if-condition ')'. Overrides sp_inside_sparen.
 sp_inside_sparen_close                    = ignore   # ignore/add/remove/force
 
-# Add or remove space before if-condition '('. Overrides sp_inside_sparen.
+# Add or remove space after if-condition '('. Overrides sp_inside_sparen.
 sp_inside_sparen_open                     = ignore   # ignore/add/remove/force
 
 # Add or remove space after ')' of 'if', 'for', 'switch', and 'while'

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -281,7 +281,7 @@ void register_options(void)
    unc_add_option("sp_inside_sparen_close", UO_sp_inside_sparen_close, AT_IARF,
                   "Add or remove space before if-condition ')'. Overrides sp_inside_sparen.");
    unc_add_option("sp_inside_sparen_open", UO_sp_inside_sparen_open, AT_IARF,
-                  "Add or remove space before if-condition '('. Overrides sp_inside_sparen.");
+                  "Add or remove space after if-condition '('. Overrides sp_inside_sparen.");
    unc_add_option("sp_after_sparen", UO_sp_after_sparen, AT_IARF,
                   "Add or remove space after ')' of 'if', 'for', 'switch', and 'while'");
    unc_add_option("sp_sparen_brace", UO_sp_sparen_brace, AT_IARF,

--- a/tests/config/sf574.cfg
+++ b/tests/config/sf574.cfg
@@ -389,7 +389,7 @@ sp_inside_sparen                          = remove   # ignore/add/remove/force
 # Add or remove space before if-condition ')'. Overrides sp_inside_sparen.
 sp_inside_sparen_close                    = remove   # ignore/add/remove/force
 
-# Add or remove space before if-condition '('. Overrides sp_inside_sparen.
+# Add or remove space after if-condition '('. Overrides sp_inside_sparen.
 sp_inside_sparen_open                     = ignore   # ignore/add/remove/force
 
 # Add or remove space after ')' of 'if', 'for', 'switch', and 'while'


### PR DESCRIPTION
Turns out the comment related to the option `sp_inside_sparen_open` contained a minor mistake which drove me crazy because I really couldn't figure out why uncrustify was adding a space after the '(' when using the option – I never actually read the variable's name (until a few minutes ago) but only the description.