### PR TITLE
Add support for indent_class_on_colon

### DIFF
--- a/etc/defaults.cfg
+++ b/etc/defaults.cfg
@@ -106,6 +106,10 @@ indent_class                              = false    # false/true
 # Whether to indent the stuff after a leading base class colon
 indent_class_colon                        = false    # false/true
 
+#  Indent based on a class colon instead of the stuff after the colon.
+# Requires indent_class_colon=true.
+indent_class_on_colon                     = false    # false/true
+
 # Whether to indent the stuff after a leading class initializer colon
 indent_constr_colon                       = false    # false/true
 

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1274,10 +1274,17 @@ void indent_text(void)
             }
             else
             {
-               next = chunk_get_next(pc);
-               if ((next != NULL) && !chunk_is_newline(next))
+               if (cpd.settings[UO_indent_class_on_colon].b && (pc->type == CT_CLASS_COLON))
                {
-                  frm.pse[frm.pse_tos].indent = next->column;
+                  frm.pse[frm.pse_tos].indent = pc->column;
+               }
+               else
+               {
+                  next = chunk_get_next(pc);
+                  if ((next != NULL) && !chunk_is_newline(next))
+                  {
+                     frm.pse[frm.pse_tos].indent = next->column;
+                  }
                }
             }
          }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -592,6 +592,9 @@ void register_options(void)
                   "Whether the 'class' body is indented");
    unc_add_option("indent_class_colon", UO_indent_class_colon, AT_BOOL,
                   "Whether to indent the stuff after a leading base class colon");
+   unc_add_option("indent_class_on_colon", UO_indent_class_on_colon, AT_BOOL,
+                  "Indent based on a class colon instead of the stuff after the colon.\n"
+                  "Requires indent_class_colon=true. Default=false");
    unc_add_option("indent_constr_colon", UO_indent_constr_colon, AT_BOOL,
                   "Whether to indent the stuff after a leading class initializer colon");
    unc_add_option("indent_ctor_init_leading", UO_indent_ctor_init_leading, AT_NUM,

--- a/src/options.h
+++ b/src/options.h
@@ -167,6 +167,7 @@ enum uncrustify_options
    UO_indent_extern,
    UO_indent_class,                         // indent stuff inside class braces
    UO_indent_class_colon,                   // indent stuff after a class colon
+   UO_indent_class_on_colon,                // indent stuff on a class colon
    UO_indent_constr_colon,                  // indent stuff after a constr colon
 
    UO_indent_ctor_init_leading,             // virtual indent from the ':' for member initializers. Default is 2. (applies to the leading colon case)

--- a/tests/config/class-on-colon-indent.cfg
+++ b/tests/config/class-on-colon-indent.cfg
@@ -1,0 +1,34 @@
+#
+#  moves class colon ops to the end of line
+#
+
+indent_with_tabs		= 0		# 1=indent to level only, 2=indent with tabs
+input_tab_size			= 8		# original tab size
+output_tab_size			= 3		# new tab size
+indent_columns			= output_tab_size
+
+pos_class_colon			= join
+pos_comma			= Trail
+pos_class_comma			= lead
+indent_class_colon		= True
+nl_class_init_args		= Add
+nl_class_colon			= Remove
+
+pos_constr_colon		= lead_force
+pos_constr_comma		= lead
+indent_class_colon      = True
+indent_constr_colon		= True
+indent_class_on_colon   = True
+indent_ctor_init_leading = 0
+nl_constr_init_args		= Add
+nl_constr_colon			= Add
+
+sp_after_class_colon                      = force
+sp_before_class_colon                     = force 
+sp_after_constr_colon                     = force  
+sp_after_comma                            = force 
+
+sp_inside_fparen		= force
+sp_after_dc = remove
+sp_before_dc = remove
+

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -59,6 +59,7 @@
 30063 class-colon-pos-eol-add.cfg      cpp/class-init.cpp
 30064 class-colon-pos-sol-add.cfg      cpp/class-init.cpp
 30065 class-colon-pos-sol.cfg          cpp/Example.h
+30066 class-on-colon-indent.cfg        cpp/class-init.cpp
 
 30070 nl_func_scope_name.cfg           cpp/nl_func_scope_name.cpp
 

--- a/tests/output/cpp/30066-class-init.cpp
+++ b/tests/output/cpp/30066-class-init.cpp
@@ -1,0 +1,68 @@
+
+class Foo : public Bar
+{
+
+};
+
+#define CTOR( i, _ ) : T( X()) \
+                     , y() \
+{ }
+
+class Foo2 : public Bar
+{
+
+};
+
+class GLOX_API ClientBase : public Class
+                          , public OtherClass
+                          , public ThridClass
+                          , public ForthClass
+{
+public:
+ClientBase( const ClientBase & f ){
+   // do something
+}
+};
+
+ClientBase::ClientBase ( const std::string& ns,
+                         const std::string& ns1,
+                         const std::string& ns2 )
+{
+
+}
+
+Foo::Foo( int bar )
+   : someVar( bar )
+   , othervar( 0 )
+{
+}
+
+Foo::Foo( int bar )
+   : someVar( bar )
+   , othervar( 0 )
+{
+}
+
+Foo::Foo( int bar )
+   : someVar( bar )
+   , othervar( 0 )
+{
+}
+
+Foo::Foo( int bar )
+   : someVar( bar )
+   , othervar( 0 )
+{
+}
+
+Foo::Foo( int bar )
+   : someVar( bar )
+   , othervar( 0 )
+{
+}
+
+Foo::Foo( int bar )
+   : someVar( bar )
+   , othervar( 0 )
+{
+}


### PR DESCRIPTION
I'd like to be able to indent base class specifications on colon. Example:
```
class MyClass : public Base1
              , public Base2
              , public Base3 
```

So I added a new parameter indent_class_on_colon which switches the behavior. Without this change the result would be this:
```
class MyClass : public Base1
                , public Base2
                , public Base3 
```

