### PR TITLE
Fixed bug with backslash at end of comment affecting the next line in C#...

### DIFF
--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -280,6 +280,7 @@ static bool parse_comment(tok_ctx& ctx, chunk_t& pc)
 {
    int  ch;
    bool is_d    = (cpd.lang_flags & LANG_D) != 0;
+   bool is_cs   = (cpd.lang_flags & LANG_CS) != 0;
    int  d_level = 0;
    int  bs_cnt;
 
@@ -311,7 +312,7 @@ static bool parse_comment(tok_ctx& ctx, chunk_t& pc)
             {
                break;
             }
-            if (ch == '\\')
+            if (ch == '\\' && !is_cs) /* backslashes aren't special in comments in C# */
             {
                bs_cnt++;
             }

--- a/tests/c-sharp.test
+++ b/tests/c-sharp.test
@@ -40,3 +40,5 @@
 10110 mda_space_a.cfg          cs/mdarray_space.cs
 10111 mda_space_b.cfg          cs/mdarray_space.cs
 10112 mda_space_c.cfg          cs/mdarray_space.cs
+
+10120 empty.cfg                cs/cmt_backslash_eol.cs

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -93,6 +93,7 @@
 30203 cmt_indent-3.cfg                 cpp/cmt_indent.cpp
 30204 comment-align.cfg                cpp/comment-align.cpp
 30205 cmt_right.cfg                    cpp/cmt_right.cpp
+30206 empty.cfg                        cpp/cmt_backslash_eol.cpp
 
 30250 align_fcall.cfg                  cpp/align_fcall.cpp
 30251 align_fcall-2.cfg                cpp/align_fcall.cpp

--- a/tests/input/cpp/cmt_backslash_eol.cpp
+++ b/tests/input/cpp/cmt_backslash_eol.cpp
@@ -1,0 +1,4 @@
+foo();
+// test \
+blah();
+bar();

--- a/tests/input/cs/cmt_backslash_eol.cs
+++ b/tests/input/cs/cmt_backslash_eol.cs
@@ -1,0 +1,4 @@
+foo();
+// test \
+blah();
+bar();

--- a/tests/output/cpp/30206-cmt_backslash_eol.cpp
+++ b/tests/output/cpp/30206-cmt_backslash_eol.cpp
@@ -1,0 +1,4 @@
+foo();
+// test \
+// blah();
+bar();

--- a/tests/output/cs/10120-cmt_backslash_eol.cs
+++ b/tests/output/cs/10120-cmt_backslash_eol.cs
@@ -1,0 +1,4 @@
+foo();
+// test \
+blah();
+bar();


### PR DESCRIPTION
.... C# has no preprocessor, and backslashes at EOL don't mean anything special.

Also added tests for C# to verify fix, and to C++ to make sure normal behavior maintained.