### PR TITLE
Keep trailing space in C++ comments if it follows backslash to prevent '\' from turning into line continuation

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -369,7 +369,12 @@ void output_text(FILE *pfile)
       }
       else if (pc->type == CT_COMMENT_CPP)
       {
+         bool tmp = cpd.output_trailspace;
+         // keep trailing spaces if they are still present in a chunk;
+         // note that tokenize() already strips spaces in comments, so if they made it up to here, they are to stay
+         cpd.output_trailspace = true;
          pc = output_comment_cpp(pc);
+         cpd.output_trailspace = tmp;
       }
       else if (pc->type == CT_COMMENT)
       {

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -1616,6 +1616,10 @@ void tokenize(const deque<int>& data, chunk_t *ref)
              ((chunk.str[chunk.str.size() - 1] == ' ') ||
               (chunk.str[chunk.str.size() - 1] == '\t')))
       {
+         // If comment contains backslash '\' followed by whitespace chars, keep last one;
+         // this will prevent it from turning '\' into line continuation.
+         if (chunk.str.size() > 1 && chunk.str[chunk.str.size() - 2] == '\\')
+            break;
          chunk.str.pop_back();
       }
 


### PR DESCRIPTION
To avoid surprises when running uncrustify on large codebases I want to to keep following lines intact:

// some path: c:\dir\ 
// start block \/
// end block /\ 

Note that there's a trailing space in two comments. This space keeps '\' from acting as a line continuation.
If space is stripped, line following the comment is swallowed (turns into a comment too).