### PR TITLE
New option 'string_replace_tab_chars' that will convert tab chars found in ordinary literal C style strings to '\t' instead.

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -169,6 +169,8 @@ void register_options(void)
                   "The ASCII value of the string escape char, usually 92 (\\) or 94 (^). (Pawn)", "", 0, 255);
    unc_add_option("string_escape_char2", UO_string_escape_char2, AT_NUM,
                   "Alternate string escape char for Pawn. Only works right before the quote char.", "", 0, 255);
+   unc_add_option("string_replace_tab_chars", UO_string_replace_tab_chars, AT_BOOL,
+                  "Replace tab characters found in string literals with the escape sequence \\t instead.");
    unc_add_option("tok_split_gte", UO_tok_split_gte, AT_BOOL,
                   "Allow interpreting '>=' and '>>=' as part of a template in 'void f(list<list<B>>=val);'.\n"
                   "If true (default), 'assert(x<0 && y>=3)' will be broken.\n"

--- a/src/options.h
+++ b/src/options.h
@@ -695,6 +695,7 @@ enum uncrustify_options
 
    UO_string_escape_char,       // the string escape char to use
    UO_string_escape_char2,      // the string escape char to use
+   UO_string_replace_tab_chars, // replace tab chars found in strings to the escape sequence \t
    UO_disable_processing_cmt,   // override UNCRUSTIFY_DEFAULT_OFF_TEXT
    UO_enable_processing_cmt,	// override UNCRUSTIFY_DEFAULT_ON_TEXT
 

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -791,6 +791,7 @@ static bool parse_string(tok_ctx& ctx, chunk_t& pc, int quote_idx, bool allow_es
    int  end_ch;
    char escape_char  = cpd.settings[UO_string_escape_char].n;
    char escape_char2 = cpd.settings[UO_string_escape_char2].n;
+   bool should_escape_tabs = cpd.settings[UO_string_replace_tab_chars].b && (cpd.lang_flags & LANG_ALLC);
 
    pc.str.clear();
    while (quote_idx-- > 0)
@@ -804,7 +805,17 @@ static bool parse_string(tok_ctx& ctx, chunk_t& pc, int quote_idx, bool allow_es
 
    while (ctx.more())
    {
+      int lastcol = ctx.c.col;
       int ch = ctx.get();
+
+      if ((ch == '\t') && should_escape_tabs)
+      {
+         ctx.c.col = lastcol + 2;
+         pc.str.append(escape_char);
+         pc.str.append('t');
+         continue;
+      }
+
       pc.str.append(ch);
       if (ch == '\n')
       {

--- a/tests/config/string_replace_tab_chars.cfg
+++ b/tests/config/string_replace_tab_chars.cfg
@@ -1,0 +1,1 @@
+string_replace_tab_chars=true

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -220,4 +220,7 @@
 31593 sf593.cfg                        cpp/sf593.cpp
 
 31700 toggle_processing_cmt.cfg        cpp/toggle_processing_cmt.cpp
-31701 toggle_processing_cmt2.cfg        cpp/toggle_processing_cmt2.cpp
+31701 toggle_processing_cmt2.cfg       cpp/toggle_processing_cmt2.cpp
+
+31710 empty.cfg                        cpp/string_replace_tab_chars.cpp
+31711 string_replace_tab_chars.cfg     cpp/string_replace_tab_chars.cpp

--- a/tests/input/cpp/string_replace_tab_chars.cpp
+++ b/tests/input/cpp/string_replace_tab_chars.cpp
@@ -1,0 +1,3 @@
+void f() {
+	 			auto x = "	test\t 	 	 		...   ???";
+}

--- a/tests/output/cpp/31710-string_replace_tab_chars.cpp
+++ b/tests/output/cpp/31710-string_replace_tab_chars.cpp
@@ -1,0 +1,3 @@
+void f() {
+	auto x = "	test\t                          ...   ???";
+}

--- a/tests/output/cpp/31711-string_replace_tab_chars.cpp
+++ b/tests/output/cpp/31711-string_replace_tab_chars.cpp
@@ -1,0 +1,3 @@
+void f() {
+	auto x = "\ttest\t \t \t \t\t...   ???";
+}


### PR DESCRIPTION
It's very difficult to have tab chars in strings participate in reformatting of the outer code in a consistent way. For example, unit tests that compare code in strings against files on disk will suddenly fail if the contents of the strings change in any way. Switching to \t chars is one way to avoid this problem, plus make the code more readable.
