### PR TITLE
Made *INDENT-OFF* truly disable all reformatting

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -695,8 +695,8 @@ enum uncrustify_options
 
    UO_string_escape_char,       // the string escape char to use
    UO_string_escape_char2,      // the string escape char to use
-   UO_disable_processing_cmt,   // override UNCRUSTIFY_DEFAULT_OFF_TEXT
-   UO_enable_processing_cmt,	// override UNCRUSTIFY_DEFAULT_ON_TEXT
+   UO_disable_processing_cmt,   // override UNCRUSTIFY_OFF_TEXT
+   UO_enable_processing_cmt,    // override UNCRUSTIFY_ON_TEXT
 
    /* Hack, add comments to the ends of namespaces */
    UO_mod_add_long_namespace_closebrace_comment,

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -126,11 +126,19 @@ static void add_text(const char *ascii_text)
 }
 
 
-static void add_text(const unc_text& text)
+static void add_text(const unc_text& text, bool is_ignored = false)
 {
    for (int idx = 0; idx < text.size(); idx++)
    {
-      add_char(text[idx]);
+      char ch = text[idx];
+      if (is_ignored)
+      {
+         write_char(ch);
+      }
+      else
+      {
+         add_char(ch);
+      }
    }
 }
 
@@ -383,7 +391,7 @@ void output_text(FILE *pfile)
       else if ((pc->type == CT_JUNK) || (pc->type == CT_IGNORED))
       {
          /* do not adjust the column for junk */
-         add_text(pc->str);
+         add_text(pc->str, true);
       }
       else if (pc->len() == 0)
       {

--- a/tests/input/cpp/indent-off.cpp
+++ b/tests/input/cpp/indent-off.cpp
@@ -11,11 +11,15 @@ void operator()();
    void operator+(int){}  \
     void operator()(){}
 
+     void func() {
+	 			auto x = "	test\t 	 	 		...   ???";}
   };
 /* *INDENT-ON* */
 struct Y {
 void operator-(int){}
 void operator+(int){}
 void operator()(){}
+     void func() {
+	 			auto x = "	test\t 	 	 		...   ???";}
 };
 

--- a/tests/output/cpp/30920-indent-off.cpp
+++ b/tests/output/cpp/30920-indent-off.cpp
@@ -12,6 +12,8 @@ struct X
    void operator+(int){}  \
     void operator()(){}
 
+     void func() {
+	 			auto x = "	test\t 	 	 		...   ???";}
   };
 /* *INDENT-ON* */
 struct Y
@@ -19,5 +21,9 @@ struct Y
    void operator-(int){}
    void operator+(int){}
    void operator()(){}
+   void func()
+   {
+      auto x = "	test\t            ...   ???";
+   }
 };
 


### PR DESCRIPTION
Previously was still reformatting tab chars found in the ignored chunks.
