### PR TITLE
Add a new option for indenting continued shift expressions, fixes issue #314

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -620,6 +620,9 @@ void register_options(void)
                   "Amount to indent variable declarations after a open brace. neg=relative, pos=absolute");
    unc_add_option("indent_var_def_cont", UO_indent_var_def_cont, AT_BOOL,
                   "Indent continued variable declarations instead of aligning.");
+   unc_add_option("indent_shift", UO_indent_shift, AT_BOOL,
+                  "Indent continued shift expressions ('<<' and '>>') instead of aligning.\n"
+                  "Turn align_left_shift off when enabling this.");
 
    unc_add_option("indent_func_def_force_col1", UO_indent_func_def_force_col1, AT_BOOL,
                   "True:  force indentation of function definition to start in column 1\n"

--- a/src/options.h
+++ b/src/options.h
@@ -192,6 +192,7 @@ enum uncrustify_options
    UO_indent_else_if,
    UO_indent_var_def_blk,        // indent a variable def block that appears at the top
    UO_indent_var_def_cont,
+   UO_indent_shift,              // if a shift expression spans multiple lines, indent
 
    /*
     * Misc inter-element spacing

--- a/tests/config/indent_shift.cfg
+++ b/tests/config/indent_shift.cfg
@@ -1,0 +1,4 @@
+align_left_shift=false
+indent_shift=true
+indent_continue=4
+indent_columns=4

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -115,6 +115,9 @@
 
 30280 sf557.cfg                        cpp/sf557.cpp
 
+30290 indent_shift.cfg                 cpp/align_left_shift.cpp
+30291 indent_shift.cfg                 cpp/indent_shift.cpp
+
 30300 ben.cfg                          cpp/enum_shr.cpp
 30301 al.cfg                           cpp/enum_class.h
 30310 sp_word_brace_force.cfg          cpp/uniform_initialization.cpp

--- a/tests/input/cpp/indent_shift.cpp
+++ b/tests/input/cpp/indent_shift.cpp
@@ -1,0 +1,55 @@
+// We want simple 4-space indentation for each nesting "level".
+
+// cannot find a way to tell uncrustify to indent the line with parenthesis
+int case2() {
+
+    std::out <<
+       "hello " << "world " <<
+     (who ? "and " : "or ") <<
+			"all " <<
+  "others" << ";" << std::endl;
+
+    // and
+
+    std::out <<
+       "hello " << "world " <<
+     ("and ") <<
+        "all " <<
+      "others" << ";" << std::endl;
+}
+
+
+// uncrustify aligns (with the << on the first line) instead of indenting
+void case3()
+{
+
+    std::out << "hello "
+			<< "world "
+      << (who ? "and " : "or ")
+       << "all "
+          << "others" << ";" << std::endl;
+
+    // this often works better, but has problems with parentheses:
+
+    std::out << "hello " <<
+         "world " <<
+     (who ? "and " : "or ") <<
+    "all " <<
+   "others" << ";" << std::endl;
+}
+
+// uncrustify does not indent >> at all!
+void case4()
+{
+    std::in >> a
+		>> b
+      >> (who ? c : d) >>
+    >> e;
+
+    // and
+
+    std::in >> a >>
+     b >>
+       (who ? c : d) >>
+   e;
+}

--- a/tests/output/cpp/30290-align_left_shift.cpp
+++ b/tests/output/cpp/30290-align_left_shift.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#define MACRO(x) x
+int main()
+{
+    int X[1];
+    MACRO(std::cout << X
+            << X[0]);
+    std::cout << X
+        << X;
+    std::cout2 << X
+        << X;
+    std::cout << X
+        << X[0];
+    std::cout <<
+        X <<
+        Y;
+    std::cout
+        << X
+        << Y;
+    std::cout
+        <<
+        X
+        <<
+        Y;
+}
+
+#define A_LONG_MACRO_NAME(x) x
+
+void f() {
+    std::cout << "Hello, "
+        << "World!"
+        << std::endl;
+    A_LONG_MACRO_NAME(std::cout << "Hello, "
+            << "World!"
+            << std::endl);
+    A_LONG_MACRO_NAME(
+            std::cout << "Hello, "
+            << "World!"
+            << std::endl);
+}
+

--- a/tests/output/cpp/30291-indent_shift.cpp
+++ b/tests/output/cpp/30291-indent_shift.cpp
@@ -1,0 +1,55 @@
+// We want simple 4-space indentation for each nesting "level".
+
+// cannot find a way to tell uncrustify to indent the line with parenthesis
+int case2() {
+
+    std::out <<
+        "hello " << "world " <<
+        (who ? "and " : "or ") <<
+        "all " <<
+        "others" << ";" << std::endl;
+
+    // and
+
+    std::out <<
+        "hello " << "world " <<
+        ("and ") <<
+        "all " <<
+        "others" << ";" << std::endl;
+}
+
+
+// uncrustify aligns (with the << on the first line) instead of indenting
+void case3()
+{
+
+    std::out << "hello "
+        << "world "
+        << (who ? "and " : "or ")
+        << "all "
+        << "others" << ";" << std::endl;
+
+    // this often works better, but has problems with parentheses:
+
+    std::out << "hello " <<
+        "world " <<
+        (who ? "and " : "or ") <<
+        "all " <<
+        "others" << ";" << std::endl;
+}
+
+// uncrustify does not indent >> at all!
+void case4()
+{
+    std::in >> a
+        >> b
+        >> (who ? c : d) >>
+        >> e;
+
+    // and
+
+    std::in >> a >>
+        b >>
+        (who ? c : d) >>
+        e;
+}


### PR DESCRIPTION
Fixes #314. Including both a new more extensive test case
as well as an adapted existing test case.

Signed-off-by: Lauri Kasanen <curaga@operamail.com>