### PR TITLE
Bugfix: Undesired effect of disable_processing_cmt

### DIFF
--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -454,7 +454,7 @@ static bool parse_comment(tok_ctx& ctx, chunk_t& pc)
    if (cpd.unc_off)
    {
       const char* ontext = cpd.settings[UO_enable_processing_cmt].str;
-      if (ontext == NULL)
+      if ( (ontext == NULL) || !ontext[0] )
       {
          ontext = UNCRUSTIFY_ON_TEXT;
       }

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -468,7 +468,7 @@ static bool parse_comment(tok_ctx& ctx, chunk_t& pc)
    else
    {
       const char* offtext = cpd.settings[UO_disable_processing_cmt].str;
-      if (offtext == NULL)
+      if ( (offtext == NULL) || !offtext[0] )
       {
          offtext = UNCRUSTIFY_OFF_TEXT;
       }


### PR DESCRIPTION
The new option disable_processing_cmt that has been added recently had
an undesired side effect. Unfortunatly, due to its nature, it was
not revealed by the test facility.

Configuration created before the option was introduced works fine
even with versions containing the new option. But in the configuration
created with those new versions  the option was automatically set to "".
In the code this lead to unformatted text after the first comment!

Fixed by treating NULL and "" equally.