### PR TITLE
allow indent_ctor_init to be negative

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1278,7 +1278,7 @@ void indent_text(void)
             {
                frm.pse[frm.pse_tos].indent += cpd.settings[UO_indent_ctor_init_leading].n;
 
-               if (cpd.settings[UO_indent_ctor_init].n > 0)
+               if (cpd.settings[UO_indent_ctor_init].n != 0)
                {
                   frm.pse[frm.pse_tos].indent     += cpd.settings[UO_indent_ctor_init].n;
                   frm.pse[frm.pse_tos].indent_tmp += cpd.settings[UO_indent_ctor_init].n;


### PR DESCRIPTION
Hi,

for my style of constructor code formatting, I need to set indent_ctor_init to a negative value. Please merge this change to support this.

Thanks,
Julian