### PR TITLE
Fix: C++ bitfields were being detected in structs, but not in classes

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2350,7 +2350,13 @@ void combine_labels(void)
                   /* Must be a macro thingy, assume some sort of label */
                   set_chunk_type(next, CT_LABEL_COLON);
                }
-               else if (next->flags & (PCF_IN_STRUCT | PCF_IN_TYPEDEF))
+               else if ((tmp == NULL) || (tmp->type != CT_NUMBER && tmp->type != CT_SIZEOF))
+               {
+                  /* the CT_SIZEOF isn't great - test 31720 happens to use a sizeof expr, but this really should be able to handle any constant expr */
+                  set_chunk_type(cur, CT_LABEL);
+                  set_chunk_type(next, CT_LABEL_COLON);
+               }
+               else if (next->flags & (PCF_IN_STRUCT | PCF_IN_CLASS | PCF_IN_TYPEDEF))
                {
                   set_chunk_type(next, CT_BIT_COLON);
 
@@ -2366,11 +2372,6 @@ void combine_labels(void)
                         set_chunk_type(tmp, CT_BIT_COLON);
                      }
                   }
-               }
-               else if ((tmp == NULL) || (tmp->type != CT_NUMBER))
-               {
-                  set_chunk_type(cur, CT_LABEL);
-                  set_chunk_type(next, CT_LABEL_COLON);
                }
             }
             else if (nextprev->type == CT_FPAREN_CLOSE)

--- a/tests/cpp.test
+++ b/tests/cpp.test
@@ -224,3 +224,5 @@
 
 31710 empty.cfg                        cpp/string_replace_tab_chars.cpp
 31711 string_replace_tab_chars.cfg     cpp/string_replace_tab_chars.cpp
+
+31720 ben.cfg                          cpp/bit-colon.cpp

--- a/tests/input/cpp/bit-colon.cpp
+++ b/tests/input/cpp/bit-colon.cpp
@@ -1,0 +1,21 @@
+class C
+{
+public:
+   size_t f1 : 1;
+   size_t f1:1;
+   size_t f2 : sizeof(size_t) - 1;
+
+Q_SIGNALS:
+   void somesignal();
+};
+
+struct S
+{
+private:
+   size_t f1 : 1;
+   size_t f1:1;
+   size_t f2 : sizeof(size_t) - 1;
+
+Q_SIGNALS:
+   void somesignal();
+};

--- a/tests/output/cpp/31720-bit-colon.cpp
+++ b/tests/output/cpp/31720-bit-colon.cpp
@@ -1,0 +1,21 @@
+class C
+{
+ public:
+   size_t f1 : 1;
+   size_t f1 : 1;
+   size_t f2 : sizeof(size_t) - 1;
+
+ Q_SIGNALS:
+   void somesignal();
+};
+
+struct S
+{
+ private:
+   size_t f1 : 1;
+   size_t f1 : 1;
+   size_t f2 : sizeof(size_t) - 1;
+
+ Q_SIGNALS:
+   void somesignal();
+};


### PR DESCRIPTION
This is a second attempt at it, after confirming that automated tests all run clean.

I'm not really happy with the CT_SIZEOF in there. It gets me past the local case I have, but really it needs to work on any arbitrary compile-time expression.