### PR TITLE
Fix ObjC 'Methodcall in ternary expression'

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -16,6 +16,7 @@
 #include <cerrno>
 #include "unc_ctype.h"
 #include <cassert>
+#include <stack>
 
 static void fix_fcn_def_params(chunk_t *pc);
 static void fix_typedef(chunk_t *pc);
@@ -2237,9 +2238,12 @@ void combine_labels(void)
    chunk_t *prev;
    chunk_t *next;
    chunk_t *tmp;
-   int     question_count = 0;
    bool    hit_case       = false;
    bool    hit_class      = false;
+
+   // need a stack to handle nesting inside of OC messages, which reset the scope
+   std::stack<int> question_counts;
+   question_counts.push(0);
 
    prev = chunk_get_head();
    cur  = chunk_get_next_nc(prev);
@@ -2259,9 +2263,19 @@ void combine_labels(void)
       {
          hit_class = false;
       }
+
+      if (prev->type == CT_SQUARE_OPEN && prev->parent_type == CT_OC_MSG)
+      {
+         question_counts.push(0);
+      }
+      else if (next->type == CT_SQUARE_CLOSE && next->parent_type == CT_OC_MSG)
+      {
+         question_counts.pop();
+      }
+
       if (next->type == CT_QUESTION)
       {
-         question_count++;
+         ++question_counts.top();
       }
       else if (next->type == CT_CASE)
       {
@@ -2276,17 +2290,17 @@ void combine_labels(void)
          }
       }
       else if ((next->type == CT_COLON) ||
-               ((question_count > 0) && (next->type == CT_OC_COLON)))
+               ((question_counts.top() > 0) && (next->type == CT_OC_COLON)))
       {
          if (cur->type == CT_DEFAULT)
          {
             set_chunk_type(cur, CT_CASE);
             hit_case = true;
          }
-         if (question_count > 0 && cur->type != CT_OC_MSG_FUNC)
+         if (question_counts.top() > 0)
          {
             set_chunk_type(next, CT_COND_COLON);
-            question_count--;
+            --question_counts.top();
          }
          else if (hit_case)
          {

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2283,7 +2283,7 @@ void combine_labels(void)
             set_chunk_type(cur, CT_CASE);
             hit_case = true;
          }
-         if (question_count > 0)
+         if (question_count > 0 && cur->type != CT_OC_MSG_FUNC)
          {
             set_chunk_type(next, CT_COND_COLON);
             question_count--;

--- a/tests/config/oc_cond_colon.cfg
+++ b/tests/config/oc_cond_colon.cfg
@@ -1,3 +1,6 @@
 sp_before_send_oc_colon = force
 sp_after_send_oc_colon = force 
 sp_cond_colon = remove
+
+# without this, no_space_table's {CT_UNKNOWN,CT_SQUARE_OPEN} combo removes the space between ? and CT_SQUARE_OPEN, but not between ? and CT_WORD
+sp_cond_question = add

--- a/tests/input/oc/oc_cond_colon.m
+++ b/tests/input/oc/oc_cond_colon.m
@@ -1,1 +1,9 @@
 [self.vendorID_TextField setStringValue:string ? string : @""];
+
+x = [NSString str:path];
+x = [NSString strFormat:@"Data/%s", path];
+x = path[0] == '/' ? path : "abc";
+x = path[0] == '/' ? [NSString str:path] : [NSString strFormat:@"Data/%s", path];
+
+id<MTLBuffer> buf = data ? [metal::g_Device newBufferWithBytes:data length:len options:MTLResourceOptionCPUCacheModeDefault]
+			: [metal::g_Device newBufferWithLength:len options:MTLResourceOptionCPUCacheModeDefault];

--- a/tests/input/oc/ternary.m
+++ b/tests/input/oc/ternary.m
@@ -1,2 +1,3 @@
 NSString *str = (otherString ?: @"this is the placeholder");
 NSString *str2 = (str ? otherString : @"this is the other placeholder");
+NSString *str3 = str ? [[NSString alloc] initWithString:str] : @"this is the third placeholder";

--- a/tests/input/oc/ternary.m
+++ b/tests/input/oc/ternary.m
@@ -1,3 +1,5 @@
 NSString *str = (otherString ?: @"this is the placeholder");
 NSString *str2 = (str ? otherString : @"this is the other placeholder");
 NSString *str3 = str ? [[NSString alloc] initWithString:str] : @"this is the third placeholder";
+id str4 = str ? [self methodWithParameter1:@{@"bla": ({[self anotherMethod:@{@"id": @1}];})}
+                                andParameter2:@{@"dict_key": @{@"nested_dict_key_1": @(1), @"nested_dict_key_2": @"colon:in:string"}}] : [self anotherMethod:str? @1 : @2];

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -79,7 +79,7 @@
 
 50400  obj-c.cfg                                    oc/for.m
 
-50410  oc_cond_colon.cfg                            oc/oc_cond_colon.m
+50410  oc_cond_colon.cfg                            oc/oc_cond_colon.m OC+
 
 50500  obj-c.cfg                                    oc/code_placeholder.m
 

--- a/tests/output/oc/50016-ternary.m
+++ b/tests/output/oc/50016-ternary.m
@@ -1,3 +1,6 @@
 NSString *str  = (otherString ?: @"this is the placeholder");
 NSString *str2 = (str ? otherString : @"this is the other placeholder");
 NSString *str3 = str ?[[NSString alloc] initWithString: str] : @"this is the third placeholder";
+id       str4  = str ?[self methodWithParameter1: @{ @"bla": ({ [self anotherMethod: @{ @"id": @1 }];
+                                                              }) }
+                                   andParameter2: @{ @"dict_key": @{ @"nested_dict_key_1": @(1), @"nested_dict_key_2": @"colon:in:string" } }] :[self anotherMethod: str ? @1 : @2];

--- a/tests/output/oc/50016-ternary.m
+++ b/tests/output/oc/50016-ternary.m
@@ -1,2 +1,3 @@
 NSString *str  = (otherString ?: @"this is the placeholder");
 NSString *str2 = (str ? otherString : @"this is the other placeholder");
+NSString *str3 = str ?[[NSString alloc] initWithString: str] : @"this is the third placeholder";

--- a/tests/output/oc/50017-ternary.m
+++ b/tests/output/oc/50017-ternary.m
@@ -1,3 +1,5 @@
 NSString *str = (otherString ?: @"this is the placeholder");
 NSString *str2 = (str ? otherString : @"this is the other placeholder");
 NSString *str3 = str ? [[NSString alloc] initWithString:str] : @"this is the third placeholder";
+id str4 = str ? [self methodWithParameter1:@{@"bla": ({[self anotherMethod:@{@"id": @1}]; })}
+                 andParameter2:@{@"dict_key": @{@"nested_dict_key_1": @(1), @"nested_dict_key_2": @"colon:in:string"}}] : [self anotherMethod:str ? @1 : @2];

--- a/tests/output/oc/50017-ternary.m
+++ b/tests/output/oc/50017-ternary.m
@@ -1,2 +1,3 @@
 NSString *str = (otherString ?: @"this is the placeholder");
 NSString *str2 = (str ? otherString : @"this is the other placeholder");
+NSString *str3 = str ? [[NSString alloc] initWithString:str] : @"this is the third placeholder";

--- a/tests/output/oc/50410-oc_cond_colon.m
+++ b/tests/output/oc/50410-oc_cond_colon.m
@@ -1,1 +1,9 @@
 [self.vendorID_TextField setStringValue : string ? string:@""];
+
+x = [NSString str : path];
+x = [NSString strFormat : @"Data/%s", path];
+x = path[0] == '/' ? path:"abc";
+x = path[0] == '/' ? [NSString str : path]:[NSString strFormat : @"Data/%s", path];
+
+id<MTLBuffer> buf = data ? [metal::g_Device newBufferWithBytes : data length : len options : MTLResourceOptionCPUCacheModeDefault]
+		    :[metal::g_Device newBufferWithLength : len options : MTLResourceOptionCPUCacheModeDefault];


### PR DESCRIPTION
This PR fixes #355 

In the `combine_labels` function, every colon used to reduce the `question_count`. This is wrong if the colon occurs in an ObjC method call because in that case, all parameters of the method are preceded by a colon that is not part of the ternary expression.

I have extended the ObjC `ternary.m` test input to cover this case. 

All tests (including the new case) still pass: 

```
mexx@mexxbook tests (feature/fixObjCTernaryMethodCall) $ ./run_tests.py
Tests: ['c-sharp', 'c', 'cpp', 'd', 'java', 'pawn', 'objective-c', 'vala', 'ecma']
Processing c-sharp.test
Processing c.test
UNSTABLE: 00012
UNSTABLE: 00617
UNSTABLE: 02100
UNSTABLE: 02102
UNSTABLE: 02501
Processing cpp.test
UNSTABLE: 30265
UNSTABLE: 30815
Processing d.test
Processing java.test
Processing pawn.test
Processing objective-c.test
UNSTABLE: 50007
Processing vala.test
Processing ecma.test
Passed 509 / 509 tests
All tests passed, but some files were unstable
```

All the UNSTABLE test cases have already been UNSTABLE before my changes.