### PR TITLE
Fix for SourceForge #635 GitHub #355

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2276,7 +2276,7 @@ void combine_labels(void)
          }
       }
       else if ((next->type == CT_COLON) ||
-               ((question_count > 0) && (next->type == CT_OC_COLON)))
+               ((question_count > 0) && (next->type == CT_OC_COLON) && (cur->type != CT_OC_MSG_FUNC)))
       {
          if (cur->type == CT_DEFAULT)
          {

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -16,6 +16,7 @@
 #include <cerrno>
 #include "unc_ctype.h"
 #include <cassert>
+#include <stack>
 
 static void fix_fcn_def_params(chunk_t *pc);
 static void fix_typedef(chunk_t *pc);
@@ -2237,9 +2238,12 @@ void combine_labels(void)
    chunk_t *prev;
    chunk_t *next;
    chunk_t *tmp;
-   int     question_count = 0;
    bool    hit_case       = false;
    bool    hit_class      = false;
+
+   // need a stack to handle nesting inside of OC messages, which reset the scope
+   std::stack<int> question_counts;
+   question_counts.push(0);
 
    prev = chunk_get_head();
    cur  = chunk_get_next_nc(prev);
@@ -2259,9 +2263,19 @@ void combine_labels(void)
       {
          hit_class = false;
       }
+
+      if (prev->type == CT_SQUARE_OPEN && prev->parent_type == CT_OC_MSG)
+      {
+         question_counts.push(0);
+      }
+      else if (next->type == CT_SQUARE_CLOSE && next->parent_type == CT_OC_MSG)
+      {
+         question_counts.pop();
+      }
+
       if (next->type == CT_QUESTION)
       {
-         question_count++;
+         ++question_counts.top();
       }
       else if (next->type == CT_CASE)
       {
@@ -2276,17 +2290,17 @@ void combine_labels(void)
          }
       }
       else if ((next->type == CT_COLON) ||
-               ((question_count > 0) && (next->type == CT_OC_COLON) && (cur->type != CT_OC_MSG_FUNC)))
+               ((question_counts.top() > 0) && (next->type == CT_OC_COLON)))
       {
          if (cur->type == CT_DEFAULT)
          {
             set_chunk_type(cur, CT_CASE);
             hit_case = true;
          }
-         if (question_count > 0)
+         if (question_counts.top() > 0)
          {
             set_chunk_type(next, CT_COND_COLON);
-            question_count--;
+            --question_counts.top();
          }
          else if (hit_case)
          {

--- a/tests/config/oc_cond_colon.cfg
+++ b/tests/config/oc_cond_colon.cfg
@@ -2,5 +2,5 @@ sp_before_send_oc_colon = force
 sp_after_send_oc_colon = force 
 sp_cond_colon = remove
 
-# without this, no_space_table's {CT_UNKNOWN,CT_SQUARE_OPEN} combo removes the space between ? and opening [
+# without this, no_space_table's {CT_UNKNOWN,CT_SQUARE_OPEN} combo removes the space between ? and CT_SQUARE_OPEN, but not between ? and CT_WORD
 sp_cond_question = add

--- a/tests/config/oc_cond_colon.cfg
+++ b/tests/config/oc_cond_colon.cfg
@@ -1,3 +1,6 @@
 sp_before_send_oc_colon = force
 sp_after_send_oc_colon = force 
 sp_cond_colon = remove
+
+# without this, no_space_table's {CT_UNKNOWN,CT_SQUARE_OPEN} combo removes the space between ? and opening [
+sp_cond_question = add

--- a/tests/input/oc/oc_cond_colon.m
+++ b/tests/input/oc/oc_cond_colon.m
@@ -1,1 +1,6 @@
 [self.vendorID_TextField setStringValue:string ? string : @""];
+
+x = [NSString str:path];
+x = [NSString strFormat:@"Data/%s", path];
+x = path[0] == '/' ? path : "abc";
+x = path[0] == '/' ? [NSString str:path] : [NSString strFormat:@"Data/%s", path];

--- a/tests/input/oc/oc_cond_colon.m
+++ b/tests/input/oc/oc_cond_colon.m
@@ -4,3 +4,6 @@ x = [NSString str:path];
 x = [NSString strFormat:@"Data/%s", path];
 x = path[0] == '/' ? path : "abc";
 x = path[0] == '/' ? [NSString str:path] : [NSString strFormat:@"Data/%s", path];
+
+id<MTLBuffer> buf = data ? [metal::g_Device newBufferWithBytes:data length:len options:MTLResourceOptionCPUCacheModeDefault]
+			: [metal::g_Device newBufferWithLength:len options:MTLResourceOptionCPUCacheModeDefault];

--- a/tests/input/oc/ternary.m
+++ b/tests/input/oc/ternary.m
@@ -1,2 +1,3 @@
 NSString *str = (otherString ?: @"this is the placeholder");
 NSString *str2 = (str ? otherString : @"this is the other placeholder");
+NSString *str3 = str ? [[NSString alloc] initWithString:str] : @"this is the third placeholder";

--- a/tests/objective-c.test
+++ b/tests/objective-c.test
@@ -79,7 +79,7 @@
 
 50400  obj-c.cfg                                    oc/for.m
 
-50410  oc_cond_colon.cfg                            oc/oc_cond_colon.m
+50410  oc_cond_colon.cfg                            oc/oc_cond_colon.m OC+
 
 50500  obj-c.cfg                                    oc/code_placeholder.m
 

--- a/tests/output/oc/50016-ternary.m
+++ b/tests/output/oc/50016-ternary.m
@@ -1,2 +1,3 @@
 NSString *str  = (otherString ?: @"this is the placeholder");
 NSString *str2 = (str ? otherString : @"this is the other placeholder");
+NSString *str3 = str ?[[NSString alloc] initWithString: str] : @"this is the third placeholder";

--- a/tests/output/oc/50017-ternary.m
+++ b/tests/output/oc/50017-ternary.m
@@ -1,2 +1,3 @@
 NSString *str = (otherString ?: @"this is the placeholder");
 NSString *str2 = (str ? otherString : @"this is the other placeholder");
+NSString *str3 = str ? [[NSString alloc] initWithString:str] : @"this is the third placeholder";

--- a/tests/output/oc/50410-oc_cond_colon.m
+++ b/tests/output/oc/50410-oc_cond_colon.m
@@ -4,3 +4,6 @@ x = [NSString str : path];
 x = [NSString strFormat : @"Data/%s", path];
 x = path[0] == '/' ? path:"abc";
 x = path[0] == '/' ? [NSString str : path]:[NSString strFormat : @"Data/%s", path];
+
+id<MTLBuffer> buf = data ? [metal::g_Device newBufferWithBytes : data length : len options : MTLResourceOptionCPUCacheModeDefault]
+		    :[metal::g_Device newBufferWithLength : len options : MTLResourceOptionCPUCacheModeDefault];

--- a/tests/output/oc/50410-oc_cond_colon.m
+++ b/tests/output/oc/50410-oc_cond_colon.m
@@ -1,1 +1,6 @@
 [self.vendorID_TextField setStringValue : string ? string:@""];
+
+x = [NSString str : path];
+x = [NSString strFormat : @"Data/%s", path];
+x = path[0] == '/' ? path:"abc";
+x = path[0] == '/' ? [NSString str : path]:[NSString strFormat : @"Data/%s", path];


### PR DESCRIPTION
This fixes https://sourceforge.net/p/uncrustify/bugs/635/ (also filed as https://github.com/bengardner/uncrustify/issues/355) and adds in a test case from https://github.com/bengardner/uncrustify/pull/356.

I believe what's necessary to deal with Obj-C messages is to introduce a scope stack that tracks the 'question count' per nesting level.