### PR TITLE
add nl_while_leave_one_liners

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -1888,6 +1888,13 @@ static bool one_liner_nl_ok(chunk_t *pc)
          LOG_FMT(LNL1LINE, "false (if/else)\n");
          return(false);
       }
+
+      if (cpd.settings[UO_nl_while_leave_one_liners].b &&
+          (pc->parent_type == CT_WHILE))
+      {
+         LOG_FMT(LNL1LINE, "false (while)\n");
+         return(false);
+      }
    }
    LOG_FMT(LNL1LINE, "true\n");
    return(true);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -749,6 +749,8 @@ void register_options(void)
                   "Don't split one-line C++11 lambdas - '[]() { return 0; }'");
    unc_add_option("nl_if_leave_one_liners", UO_nl_if_leave_one_liners, AT_BOOL,
                   "Don't split one-line if/else statements - 'if(a) b++;'");
+   unc_add_option("nl_while_leave_one_liners", UO_nl_while_leave_one_liners, AT_BOOL,
+                  "Don't split one-line while statements - 'while(a) b++;'");
    unc_add_option("nl_oc_msg_leave_one_liner", UO_nl_oc_msg_leave_one_liner, AT_BOOL,
                   "Don't split one-line OC messages");
 

--- a/src/options.h
+++ b/src/options.h
@@ -590,6 +590,7 @@ enum uncrustify_options
    UO_nl_func_leave_one_liners,       // leave one-line function def bodies
    UO_nl_cpp_lambda_leave_one_liners, // leave one-line C++11 lambda bodies
    UO_nl_if_leave_one_liners,
+   UO_nl_while_leave_one_liners,
    UO_nl_case_colon_brace,
 
    UO_nl_template_class,          // newline between '>' and class in "template <x> class"


### PR DESCRIPTION
Preserve one-line while statements. It is a
straightforward extension of other leave_one_liners
options.