### PR TITLE
Use the cmake build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 2.8.3)
+
+project(uncrustify)
+
+include(ExternalProject)
+
+if(NOT WIN32)
+  ExternalProject_Add(
+    external_uncrustify
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
+    CONFIGURE_COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/configure"
+      "--prefix" "${CMAKE_CURRENT_BINARY_DIR}"
+    BUILD_COMMAND "${MAKE}"
+  )
+
+  install(
+    PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/bin/uncrustify"
+    DESTINATION bin
+  )
+
+else()
+  set(build_type "${CMAKE_BUILD_TYPE}")
+  if("${build_type} " STREQUAL " ")
+    set(build_type "Debug")
+  endif()
+
+  add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/src/uncrustify_version.h"
+    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/scripts/create_uncrustify_version_header.bat"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/scripts"
+  )
+
+  add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/win32/${build_type}/Uncrustify.exe"
+    COMMAND "devenv" "/upgrade" "${CMAKE_CURRENT_SOURCE_DIR}/win32/Uncrustify_Win32_2011.sln"
+    COMMAND "msbuild" "${CMAKE_CURRENT_SOURCE_DIR}/win32/Uncrustify_Win32_2011.sln" "/p:Configuration=${build_type}" "/p:Platform=Win32"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/uncrustify_version.h"
+  )
+
+  add_custom_target(
+    external_uncrustify ALL
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/win32/${build_type}/Uncrustify.exe"
+  )
+
+  install(
+    PROGRAMS "${CMAKE_CURRENT_SOURCE_DIR}/win32/${build_type}/Uncrustify.exe"
+    DESTINATION bin
+  )
+endif()

--- a/package.xml
+++ b/package.xml
@@ -9,4 +9,8 @@
   <license>GNU GENERAL PUBLIC LICENSE Version 3</license>
 
   <url>https://github.com/bengardner/uncrustify</url>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>uncrustify</name>
+  <version>0.61.20150413</version>
+  <description>
+    Package a newer version of uncrustify (0.61+, b6593c1, April 14th 2015).
+  </description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>GNU GENERAL PUBLIC LICENSE Version 3</license>
+
+  <url>https://github.com/bengardner/uncrustify</url>
+</package>


### PR DESCRIPTION
This depends on https://github.com/ament/ament_tools/pull/33

By doing this we avoid some warnings about this package not using certain ament specific CMake variables.