### PR TITLE
fix warnings on Windows

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1113,7 +1113,7 @@ void fix_symbols(void)
 
    mark_define_expressions();
 
-   bool is_java = cpd.lang_flags & LANG_JAVA;
+   bool is_java = (cpd.lang_flags & LANG_JAVA) != 0;
    for (pc = chunk_get_head(); pc != NULL; pc = chunk_get_next_ncnl(pc))
    {
       if ((pc->type == CT_FUNC_WRAP) ||

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -959,7 +959,7 @@ void indent_text(void)
                if (cpd.settings[UO_indent_oc_block].b ||
                    cpd.settings[UO_indent_oc_block_msg_xcode_style].b)
                {
-                  bool in_oc_msg           = (pc->flags & PCF_IN_OC_MSG);
+                  bool in_oc_msg           = (pc->flags & PCF_IN_OC_MSG) != 0;
                   bool indent_from_keyword = cpd.settings[UO_indent_oc_block_msg_from_keyword].b && in_oc_msg;
                   bool indent_from_colon   = cpd.settings[UO_indent_oc_block_msg_from_colon].b && in_oc_msg;
                   bool indent_from_caret   = cpd.settings[UO_indent_oc_block_msg_from_caret].b && in_oc_msg;


### PR DESCRIPTION
This patch gets rid of two compiler warnings on Windows:

* 'int': forcing value to bool 'true' or 'false' (performance warning)
* 'UINT64': forcing value to bool 'true' or 'false' (performance warning)