### PR TITLE
Fix issue 414: The actual global spacing options must not to be applicated to the preprocessor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ language: cpp
 before_script: ls
 
 script:
-  - make
+  - make -C Build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: cpp
+
+branches:
+  only:
+   - master
+
+before_script: ls
+
+script:
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: cpp
 
 before_script: ./configure
 
-script: make
+script: 
+  - make
+  - ./run_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: cpp
 
-before_script: ls
+before_script: ./configure
 
-script:
-  - make -C Build
+script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: cpp
 
-branches:
-  only:
-   - master
-
-before_script: pwd
+before_script: ls
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
   only:
    - master
 
-before_script: ls
+before_script: pwd
 
 script:
   - make

--- a/etc/amxmodx.cfg
+++ b/etc/amxmodx.cfg
@@ -1,207 +1,1966 @@
+# Uncrustify 0.61
+
 #
-# AMX Mod X style for Pawn (or as close as possible)
+# AMX Mod X style for Pawn
 #
 
-#######################
-# Basic Indenting Stuff
+#
+# General options
+#
 
-# (a/i/r) comment notation for add/ignore/remove which is the actual setting
-input_tab_size      = 1    # tab size on input file: usually 8
-output_tab_size     = 8    # tab size for output: usually 8
-indent_columns      = 8    # ie 3 or 8
-indent_with_tabs    = 2    # 1=only to the 'level' indent, 2=use tab indenting
-#indent_paren_nl     = 1    # indent-align under paren for open followed by nl
+# The type of line endings
+newlines                                  = auto     # auto/lf/crlf/cr
 
-pp_indent           = remove # indent preproc 1 space per level (a/i/r)
-pp_space            = remove # spaces between # and word (add/ignore/remove)
+# The original size of tabs in the input
+input_tab_size                            = 4        # number
 
-#indent_switch_case  = 1    # spaces to indent case from switch
-#indent_case_brace   = 0    # spaces to indent '{' from case
-                            # (usually 0 or indent_columns)
+# The size of tabs in the output (only used if align_with_tabs=true)
+output_tab_size                           = 4        # number
 
-#indent_brace         = 0    # spaces to indent '{' from level (usually 0)
-indent_braces        = 0    # whether to indent the braces or not
-#indent_label         = 0    # 0=left >0=col from left (absolute column),
-                             # <0=sub from brace indent (relative column)
+# The ASCII value of the string escape char, usually 92 (\) or 94 (^). (Pawn)
+# If 94 is selected, remove spaces only at the preprocessor macro functions
+# declarations and ignore adding arithmetic expressions spaces at the macro
+# function body. Ex: '#define COOL_MACRO(%1,%2)   ( %1 = %2 + 1 )' # instead of:
+# 'define COOL_MACRO( % 1 , % 2 )   ( % 1 = % 2 + 1 )', which is wrong.
+# To accomplish it, this overrides sp_inside_paren, sp_after_comma and sp_arith
+# only at the macro function declaration and body.
+string_escape_char                        = 94       # number
 
-indent_align_string    = false # True/False - indent align broken strings
-indent_col1_comment    = false # indent comments in column 1
-indent_func_call_param = false # indent continued function calls to indent_columns otherwise index_columns + spaces to align with open paren.
+# Alternate string escape char for Pawn. Only works right before the quote char.
+string_escape_char2                       = 0        # number
 
-indent_namespace    = true  # indent stuff inside namespace braces
-indent_class        = true  # indent stuff inside class braces
+# Allow interpreting '>=' and '>>=' as part of a template in 'void f(list<list<B>>=val);'.
+# If true (default), 'assert(x<0 && y>=3)' will be broken.
+# Improvements to template detection may make this option obsolete.
+tok_split_gte                             = false    # false/true
 
+# Control what to do with the UTF-8 BOM (recommend 'remove')
+utf8_bom                                  = ignore   # ignore/add/remove/force
 
-############################
-# Misc Inter-element Spacing
-#  Force,Ignore,Add,Remove
+# If the file contains bytes with values between 128 and 255, but is not UTF-8, 
+# then output as UTF-8
+utf8_byte                                 = false    # false/true
 
-# ignored by nl_*_brace = true
-sp_paren_brace       = force  # space between ')' and '{'
-sp_fparen_brace      = force  # space between ')' and '{' of function
-sp_sparen_brace      = force  # space between ')' and '{' of if, while, etc
-
-sp_after_cast        = force  # space after cast - "(int) a" vs "(int)a"
-
-sp_before_byref      = force  # space before '&' of 'fcn(int& idx)'
-
-sp_inside_fparen     = force  # space inside 'foo( xxx )' vs 'foo(xxx)'
-sp_inside_fparens    = remove # space inside 'foo( )' vs 'foo()'
-sp_inside_paren      = remove # space inside '+ ( xxx )' vs '+ (xxx)'
-sp_inside_square     = remove # space inside 'byte[ 5 ]' vs 'byte[5]'
-sp_inside_sparen     = force  # space inside 'if( xxx )' vs 'if(xxx)'
-sp_inside_angle      = ignore # space inside '<>', as in '<class T>'
-
-sp_before_sparen     = force  # space before '(' of 'if/for/while/switch'
-sp_after_sparen      = force  # space after  ')' of 'if/for/while/switch'
-                              # the do-while does not get set here
-
-sp_before_angle      = ignore # space before '<>', as in '<class T>'
-sp_after_angle       = ignore # space after  '<>', as in '<class T>'
-
-sp_before_square     = ignore # space before single '['
-sp_before_squares    = remove # space before '[]', as in 'byte []'
-
-sp_paren_paren       = force  # space between nested parens - '( (' vs '(('
-
-sp_return_paren      = remove # space between 'return' and '('
-sp_sizeof_paren      = remove # space between 'sizeof' and '('
-
-sp_after_comma       = force  # space after ','
-
-sp_arith             = force  # space around + - / * etc
-sp_bool              = force  # space around || &&
-sp_compare           = force  # space around < > ==, etc
-sp_assign            = force  # space around =, +=, etc
-
-sp_func_def_paren    = remove # space between 'func' and '(' - "foo (" vs "foo("
-sp_func_call_paren   = remove # space between 'func' and '(' - "foo (" vs "foo("
-sp_func_proto_paren  = remove # space between 'func' and '(' - "foo (" vs "foo("
-sp_func_class_paren  = remove # space between ctor/dtor and '('
-
-#sp_type_func         = 1      # space between return type and 'func'
-                               # a minimum of 1 is forced except for '*'
+# Force the output encoding to UTF-8
+utf8_force                                = false    # false/true
 
 
-sp_special_semi         = remove # space empty stmt ';' on while, if, for
-                                 # example "while (*p++ = ' ') ;"
-sp_before_semi          = remove # space before all ';'
-sp_inside_braces        = force  # space inside '{' and '}' - "{ 1, 2, 3 }"
-sp_inside_braces_enum   = force  # space inside enum '{' and '}' - "{ a, b, c }"
-sp_inside_braces_struct = force  # space inside struct/union '{' and '}'
-
-sp_macro             = force  # space between macro and value, ie '#define a 6'
-sp_macro_func        = force  # space between macro and value, ie '#define a 6'
-
-sp_square_fparen     = remove # weird pawn stuff: native yark[rect](a[rect])
-sp_after_tag         = remove # pawn: space after a tag colon
 
 
-################################
-# Code Alignment
-# (not left column spaces/tabs)
-
-align_with_tabs       = true   # use tabs for aligning (0/1)
-align_keep_tabs       = false  # keep non-indenting tabs
-align_on_tabstop      = true   # always align on tabstops
-align_nl_cont         = false  # align the back-slash \n combo (macros)
-align_enum_equ_span   = 1      # align the '=' in enums
-align_assign_span     = 1      # align on '='. 0=don't align
-align_assign_thresh   = 0      # threshold for aligning on '='. 0=no limit
-align_right_cmt_span  = 8      # align comment that end lines. 0=don't align
-align_var_def_span    = 1      # align variable defs on variable (span for regular stuff)
-align_var_def_thresh  = 0      # align variable defs threshold
-align_var_def_inline  = true   # also align inline struct/enum/union var defs
-align_var_def_star_style = 1   # the star is part of the variable name
-align_var_def_colon   = false  # align the colon in struct bit fields
-align_var_struct_span = 1      # span for struct/union (0=don't align)
-align_pp_define_span  = 1      # align bodies in #define statements
-align_pp_define_gap   = 1      # min space between define label and value "#define a <---> 16"
-
-align_struct_init_span   = 1      # align structure initializer values
-align_func_proto_span    = 1      # align function prototypes
-align_number_left        = false  # left-align numbers (not fully supported, yet)
-align_typedef_span       = 1      # align single-line typedefs
-align_typedef_gap        = 1      # minimum spacing
-align_typedef_star_style = 1      # Start aligning style
-                                  # 0: '*' not part of type
-                                  # 1: '*' part of the type - no space
-                                  # 2: '*' part of type, dangling
 
 
-#####################################
-# Newline Adding and Removing Options
-#        Add/Remove/Ignore
-
-nl_fdef_brace        = add    # "int foo() {" vs "int foo()\n{"
-nl_func_decl_start   = ignore # newline after the '(' in a function decl
-nl_func_decl_args    = ignore # newline after each ',' in a function decl
-nl_func_decl_end     = ignore # newline before the ')' in a function decl
-nl_func_type_name    = ignore # newline between return type and func name in def
-nl_func_var_def_blk  = 0      # newline after a block of variable defs
-nl_before_case       = false  # newline before 'case' statement
-nl_after_return      = false  # newline after return statement
-nl_after_case        = false  # disallow nested "case 1: a=3;"
-nl_fcall_brace       = add    # newline between function call and open brace
-nl_squeeze_ifdef     = false  # no blanks after #ifxx, #elxx, or before #endif TRUE/F
-nl_enum_brace        = ignore # nl between enum and brace
-nl_struct_brace      = ignore # nl between struct and brace
-nl_union_brace       = ignore # nl between union and brace
-nl_assign_brace      = ignore # nl between '=' and brace
-nl_class_brace       = ignore # nl between class name and brace
-nl_namespace_brace   = ignore # nl between namespace name and brace
-
-nl_do_brace          = add    # nl between do and {
-nl_if_brace          = add    # nl between if and {
-nl_for_brace         = add    # nl between for and {
-nl_else_brace        = remove # nl between else and {
-nl_while_brace       = add    # nl between while and {
-nl_switch_brace      = add    # nl between switch and {
-nl_brace_else        = remove # nl between } and else
-nl_brace_while       = add    # nl between } and while of do stmt
-
-nl_elseif_brace      = add    # nl between close paren and open brace in 'else if () {'
-
-nl_define_macro      = 0      # alter newlines in #define macros
-nl_start_of_file     = ignore # alter newlines at the start of file
-nl_start_of_file_min = 0      # min number of newlines at the start of the file
-nl_end_of_file       = ignore # alter newlines at the end of file
-nl_end_of_file_min   = 0      # min number of newlines at the end of the file
-
-pos_bool             = start  # end=move &&/|| to EOL ignore=gnore, start=move to SOL
-
-#####################
-# Blank Line Options
-
-nl_before_block_comment   = 3   # before a block comment (stand-alone
-                                # comment-multi), except after brace open
-nl_after_func_body        = 3   # after the closing brace of a function body
-nl_after_func_proto       = 3   # after each prototype
-nl_after_func_proto_group = 3   # after a block of prototypes
-nl_max                    = 3   # maximum consecutive newlines (3=2 lines)
-
-eat_blanks_after_open_brace   = true  # remove blank lines after {
-eat_blanks_before_close_brace = true  # remove blank lines before }
-
-########################
-# Code Modifying Options
-# (non-whitespace)
-
-mod_paren_on_return     = force  # add or remove paren on return
-mod_full_brace_nl       = 1      # max number of newlines to span w/o braces
-mod_full_brace_if       = ignore # add or remove braces on if
-mod_full_brace_for      = ignore # add or remove braces on for
-mod_full_brace_do       = ignore # add or remove braces on do
-mod_full_brace_while    = ignore # add or remove braces on while
-mod_pawn_semicolon      = True   # add optional semicolons
-mod_full_brace_function = add    # add optional braces on Pawn functions
 
 
-#######################
-# Comment Modifications
 
-cmt_star_cont    = true   # put a star on subsequent comment lines
-cmt_cpp_to_c     = true   # convert CPP comments to C comments
-cmt_cpp_group    = true   # if UO_cmt_cpp_to_c, try to group in one big C comment
-cmt_cpp_nl_start = true   # put a blank /* at the start of a converted group
-cmt_cpp_nl_end   = true   # put a nl before the */ in a converted group
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
+# Indenting
+# ####################################################################################################
+
+# The number of columns to indent per level.
+# Usually 2, 3, 4, or 8.
+indent_columns                            = 4        # number
+
+# The continuation indent. If non-zero, this overrides the indent of '(' and '=' 
+# continuation indents. For FreeBSD, this is set to 4. Negative value is absolute 
+# and not increased for each ( level
+indent_continue                           = 0        # number
+
+# How to use tabs when indenting code
+# 0=spaces only
+# 1=indent with tabs to brace level, align with spaces
+# 2=indent and align with tabs, using spaces when not on a tabstop
+indent_with_tabs                          = 0        # number
+
+# Comments that are not a brace level are indented with tabs on a tabstop.
+# Requires indent_with_tabs=2. If false, will use spaces.
+indent_cmt_with_tabs                      = false    # false/true
+
+# Whether to indent strings broken by '\' so that they line up
+indent_align_string                       = true    # false/true
+
+# The number of spaces to indent multi-line XML strings.
+# Requires indent_align_string=True
+indent_xml_string                         = 0        # number
+
+# Spaces to indent '{' from level
+indent_brace                              = 0        # number
+
+# Whether braces are indented to the body level
+indent_braces                             = false    # false/true
+
+# Disabled indenting function braces if indent_braces is true
+indent_braces_no_func                     = false    # false/true
+
+# Disabled indenting class braces if indent_braces is true
+indent_braces_no_class                    = false    # false/true
+
+# Disabled indenting struct braces if indent_braces is true
+indent_braces_no_struct                   = false    # false/true
+
+# Indent based on the size of the brace parent, i.e. 'if' => 3 spaces, 'for' => 4 
+# spaces, etc.
+indent_brace_parent                       = false    # false/true
+
+# Indent based on the paren open instead of the brace open in '({\n', default is to 
+# indent by brace.
+indent_paren_open_brace                   = false    # false/true
+
+# Whether the 'namespace' body is indented
+indent_namespace                          = true    # false/true
+
+# Only indent one namespace and no sub-namepaces.
+# Requires indent_namespace=true.
+indent_namespace_single_indent            = false    # false/true
+
+# The number of spaces to indent a namespace block
+indent_namespace_level                    = 0        # number
+
+# If the body of the namespace is longer than this number, it won't be indented.
+# Requires indent_namespace=true. Default=0 (no limit)
+indent_namespace_limit                    = 0        # number
+
+# Whether the 'extern "C"' body is indented
+indent_extern                             = false    # false/true
+
+# Whether the 'class' body is indented
+indent_class                              = true    # false/true
+
+# Whether to indent the stuff after a leading base class colon
+indent_class_colon                        = false    # false/true
+
+# Whether to indent the stuff after a leading class initializer colon
+indent_constr_colon                       = false    # false/true
+
+# Virtual indent from the ':' for member initializers. Default is 2
+indent_ctor_init_leading                  = 2        # number
+
+# Additional indenting for constructor initializer list
+indent_ctor_init                          = 0        # number
+
+# False=treat 'else\nif' as 'else if' for indenting purposes
+# True=indent the 'if' one level
+indent_else_if                            = false    # false/true
+
+# Amount to indent variable declarations after a open brace. neg=relative, pos=absolute
+indent_var_def_blk                        = 0        # number
+
+# Indent continued variable declarations instead of aligning.
+indent_var_def_cont                       = false    # false/true
+
+# True:  force indentation of function definition to start in column 1
+# False: use the default behavior
+indent_func_def_force_col1                = false    # false/true
+
+# True:  indent continued function call parameters one indent level
+# False: align parameters under the open paren
+indent_func_call_param                    = true    # false/true
+
+# Same as indent_func_call_param, but for function defs
+indent_func_def_param                     = false    # false/true
+
+# Same as indent_func_call_param, but for function protos
+indent_func_proto_param                   = false    # false/true
+
+# Same as indent_func_call_param, but for class declarations
+indent_func_class_param                   = false    # false/true
+
+# Same as indent_func_call_param, but for class variable constructors
+indent_func_ctor_var_param                = false    # false/true
+
+# Same as indent_func_call_param, but for templates
+indent_template_param                     = false    # false/true
+
+# Double the indent for indent_func_xxx_param options
+indent_func_param_double                  = true    # false/true
+
+# Indentation column for standalone 'const' function decl/proto qualifier
+indent_func_const                         = 0        # number
+
+# Indentation column for standalone 'throw' function decl/proto qualifier
+indent_func_throw                         = 0        # number
+
+# The number of spaces to indent a continued '->' or '.'
+# Usually set to 0, 1, or indent_columns.
+indent_member                             = indent_columns        # number
+
+# Spaces to indent single line ('//') comments on lines before code
+indent_sing_line_comments                 = 0        # number
+
+# If set, will indent trailing single line ('//') comments relative
+# to the code instead of trying to keep the same absolute column
+indent_relative_single_line_comments      = false    # false/true
+
+# Spaces to indent 'case' from 'switch'
+# Usually 0 or indent_columns.
+indent_switch_case                        = indent_columns        # number
+
+# Spaces to shift the 'case' line, without affecting any other lines
+# Usually 0.
+indent_case_shift                         = 0        # number
+
+# Spaces to indent '{' from 'case'.
+# By default, the brace will appear under the 'c' in case.
+# Usually set to 0 or indent_columns.
+indent_case_brace                         = 0        # number
+
+# Whether to indent comments found in first column
+indent_col1_comment                       = false    # false/true
+
+# How to indent goto labels
+#  >0 : absolute column where 1 is the leftmost column
+#  <=0 : subtract from brace indent
+indent_label                              = 0        # number
+
+# Same as indent_label, but for access specifiers that are followed by a colon
+indent_access_spec                        = 1        # number
+
+# Indent the code after an access specifier by one level.
+# If set, this option forces 'indent_access_spec=0'
+indent_access_spec_body                   = false    # false/true
+
+# If an open paren is followed by a newline, indent the next line so that it lines up 
+# after the open paren (not recommended)
+indent_paren_nl                           = false    # false/true
+
+# Controls the indent of a close paren after a newline.
+# 0: Indent to body level
+# 1: Align under the open paren
+# 2: Indent to the brace level
+indent_paren_close                        = 0        # number
+
+# Controls the indent of a comma when inside a paren. If TRUE, aligns under the 
+# open paren
+indent_comma_paren                        = false    # false/true
+
+# Controls the indent of a BOOL operator when inside a paren. If TRUE, aligns 
+# under the open paren
+indent_bool_paren                         = false    # false/true
+
+# If 'indent_bool_paren' is true, controls the indent of the first expression. If TRUE, 
+# aligns the first expression to the following ones
+indent_first_bool_expr                    = false    # false/true
+
+# If an open square is followed by a newline, indent the next line so that it lines up 
+# after the open square (not recommended)
+indent_square_nl                          = false    # false/true
+
+# Don't change the relative indent of ESQL/C 'EXEC SQL' bodies
+indent_preserve_sql                       = false    # false/true
+
+# Align continued statements at the '='. Default=True
+# If FALSE or the '=' is followed by a newline, the next line is indent one tab.
+indent_align_assign                       = true     # false/true
+
+# Indent OC blocks at brace level instead of usual rules.
+indent_oc_block                           = false    # false/true
+
+# Indent OC blocks in a message relative to the parameter name.
+# 0=use indent_oc_block rules, 1+=spaces to indent
+indent_oc_block_msg                       = 0        # number
+
+# Minimum indent for subsequent parameters
+indent_oc_msg_colon                       = 0        # number
+
+# If true, prioritize aligning with initial colon (and stripping spaces from lines, if necessary).
+# Default is true.
+indent_oc_msg_prioritize_first_colon      = true     # false/true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented the way that 
+# Xcode does by default (from keyword if the parameter is on its own line; otherwise, 
+# from the previous indentation level).
+indent_oc_block_msg_xcode_style           = false    # false/true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented from where 
+# the brace is relative to a msg keyword.
+indent_oc_block_msg_from_keyword          = false    # false/true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented from where 
+# the brace is relative to a msg colon.
+indent_oc_block_msg_from_colon            = false    # false/true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented from where 
+# the block caret is.
+indent_oc_block_msg_from_caret            = false    # false/true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented from where 
+# the brace is.
+indent_oc_block_msg_from_brace            = false    # false/true
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
+# Spacing options
+# ####################################################################################################
+
+# Add or remove space around arithmetic operator '+', '-', '/', '*', etc
+sp_arith                                  = add   # ignore/add/remove/force
+
+# Add or remove space around assignment operator '=', '+=', etc
+sp_assign                                 = add   # ignore/add/remove/force
+
+# Add or remove space around '=' in C++11 lambda capture specifications. Overrides sp_assign
+sp_cpp_lambda_assign                      = ignore   # ignore/add/remove/force
+
+# Add or remove space after the capture specification in C++11 lambda.
+sp_cpp_lambda_paren                       = ignore   # ignore/add/remove/force
+
+# Add or remove space around assignment operator '=' in a prototype
+sp_assign_default                         = ignore   # ignore/add/remove/force
+
+# Add or remove space before assignment operator '=', '+=', etc. Overrides sp_assign.
+sp_before_assign                          = ignore   # ignore/add/remove/force
+
+# Add or remove space after assignment operator '=', '+=', etc. Overrides sp_assign.
+sp_after_assign                           = ignore   # ignore/add/remove/force
+
+# Add or remove space in 'NS_ENUM ('
+sp_enum_paren                             = ignore   # ignore/add/remove/force
+
+# Add or remove space around assignment '=' in enum
+sp_enum_assign                            = ignore   # ignore/add/remove/force
+
+# Add or remove space before assignment '=' in enum. Overrides sp_enum_assign.
+sp_enum_before_assign                     = ignore   # ignore/add/remove/force
+
+# Add or remove space after assignment '=' in enum. Overrides sp_enum_assign.
+sp_enum_after_assign                      = ignore   # ignore/add/remove/force
+
+# Add or remove space around preprocessor '##' concatenation operator. Default=Add
+sp_pp_concat                              = add      # ignore/add/remove/force
+
+# Add or remove space after preprocessor '#' stringify operator. Also affects the '#@' 
+# charizing operator.
+sp_pp_stringify                           = ignore   # ignore/add/remove/force
+
+# Add or remove space before preprocessor '#' stringify operator as in '#define x(y) L#y'.
+sp_before_pp_stringify                    = ignore   # ignore/add/remove/force
+
+# Add or remove space around boolean operators '&&' and '||'
+sp_bool                                   = add   # ignore/add/remove/force
+
+# Add or remove space around compare operator '<', '>', '==', etc
+sp_compare                                = add   # ignore/add/remove/force
+
+# Add or remove space inside '(' and ')'
+sp_inside_paren                           = add   # ignore/add/remove/force
+
+# Add or remove space between nested parens: '((' vs ') )'
+sp_paren_paren                            = add   # ignore/add/remove/force
+
+# Add or remove space between back-to-back parens: ')(' vs ') ('
+sp_cparen_oparen                          = ignore   # ignore/add/remove/force
+
+# Whether to balance spaces inside nested parens
+sp_balance_nested_parens                  = false    # false/true
+
+# Add or remove space between ')' and '{'
+sp_paren_brace                            = add   # ignore/add/remove/force
+
+# Add or remove space before pointer star '*'
+sp_before_ptr_star                        = ignore   # ignore/add/remove/force
+
+# Add or remove space before pointer star '*' that isn't followed by a variable name
+# If set to 'ignore', sp_before_ptr_star is used instead.
+sp_before_unnamed_ptr_star                = ignore   # ignore/add/remove/force
+
+# Add or remove space between pointer stars '*'
+sp_between_ptr_star                       = ignore   # ignore/add/remove/force
+
+# Add or remove space after pointer star '*', if followed by a word.
+sp_after_ptr_star                         = ignore   # ignore/add/remove/force
+
+# Add or remove space after pointer star '*', if followed by a qualifier.
+sp_after_ptr_star_qualifier               = ignore   # ignore/add/remove/force
+
+# Add or remove space after a pointer star '*', if followed by a func proto/def.
+sp_after_ptr_star_func                    = ignore   # ignore/add/remove/force
+
+# Add or remove space after a pointer star '*', if followed by an open paren (function types).
+sp_ptr_star_paren                         = ignore   # ignore/add/remove/force
+
+# Add or remove space before a pointer star '*', if followed by a func proto/def.
+sp_before_ptr_star_func                   = ignore   # ignore/add/remove/force
+
+# Add or remove space before a reference sign '&'
+sp_before_byref                           = add   # ignore/add/remove/force
+
+# Add or remove space before a reference sign '&' that isn't followed by a variable name
+# If set to 'ignore', sp_before_byref is used instead.
+sp_before_unnamed_byref                   = ignore   # ignore/add/remove/force
+
+# Add or remove space after reference sign '&', if followed by a word.
+sp_after_byref                            = ignore   # ignore/add/remove/force
+
+# Add or remove space after a reference sign '&', if followed by a func proto/def.
+sp_after_byref_func                       = ignore   # ignore/add/remove/force
+
+# Add or remove space before a reference sign '&', if followed by a func proto/def.
+sp_before_byref_func                      = ignore   # ignore/add/remove/force
+
+# Add or remove space between type and word. Default=Force
+sp_after_type                             = add    # ignore/add/remove/force
+
+# Add or remove space before the paren in the D constructs 'template Foo(' and 'class Foo('.
+sp_before_template_paren                  = ignore   # ignore/add/remove/force
+
+# Add or remove space in 'template <' vs 'template<'.
+# If set to ignore, sp_before_angle is used.
+sp_template_angle                         = ignore   # ignore/add/remove/force
+
+# Add or remove space before '<>'
+sp_before_angle                           = ignore   # ignore/add/remove/force
+
+# Add or remove space inside '<' and '>'
+sp_inside_angle                           = ignore   # ignore/add/remove/force
+
+# Add or remove space after '<>'
+sp_after_angle                            = ignore   # ignore/add/remove/force
+
+# Add or remove space between '<>' and '(' as found in 'new List<byte>();'
+sp_angle_paren                            = ignore   # ignore/add/remove/force
+
+# Add or remove space between '<>' and a word as in 'List<byte> m;'
+sp_angle_word                             = ignore   # ignore/add/remove/force
+
+# Add or remove space between '>' and '>' in '>>' (template stuff C++/C# only). Default=Add
+sp_angle_shift                            = add      # ignore/add/remove/force
+
+# Permit removal of the space between '>>' in 'foo<bar<int> >' (C++11 only). Default=False
+# sp_angle_shift cannot remove the space without this option.
+sp_permit_cpp11_shift                     = false    # false/true
+
+# Add or remove space before '(' of 'if', 'for', 'switch', and 'while'
+sp_before_sparen                          = remove   # ignore/add/remove/force
+
+# Add or remove space inside if-condition '(' and ')'
+sp_inside_sparen                          = add   # ignore/add/remove/force
+
+# Add or remove space before if-condition ')'. Overrides sp_inside_sparen.
+sp_inside_sparen_close                    = ignore   # ignore/add/remove/force
+
+# Add or remove space before if-condition '('. Overrides sp_inside_sparen.
+sp_inside_sparen_open                     = ignore   # ignore/add/remove/force
+
+# Add or remove space after ')' of 'if', 'for', 'switch', and 'while'
+sp_after_sparen                           = add   # ignore/add/remove/force
+
+# Add or remove space between ')' and '{' of 'if', 'for', 'switch', and 'while'
+sp_sparen_brace                           = add   # ignore/add/remove/force
+
+# Add or remove space between 'invariant' and '(' in the D language.
+sp_invariant_paren                        = ignore   # ignore/add/remove/force
+
+# Add or remove space after the ')' in 'invariant (C) c' in the D language.
+sp_after_invariant_paren                  = ignore   # ignore/add/remove/force
+
+# Add or remove space before empty statement ';' on 'if', 'for' and 'while'
+# example "while (*p++ = ' ') ;"
+sp_special_semi                           = ignore   # ignore/add/remove/force
+
+# Add or remove space before ';'. Default=Remove
+sp_before_semi                            = remove   # ignore/add/remove/force
+
+# Add or remove space before ';' in non-empty 'for' statements
+sp_before_semi_for                        = remove   # ignore/add/remove/force
+
+# Add or remove space before a semicolon of an empty part of a for statement.
+sp_before_semi_for_empty                  = add   # ignore/add/remove/force
+
+# Add or remove space after ';', except when followed by a comment. Default=Add
+sp_after_semi                             = add      # ignore/add/remove/force
+
+# Add or remove space after ';' in non-empty 'for' statements. Default=Force
+sp_after_semi_for                         = add    # ignore/add/remove/force
+
+# Add or remove space after the final semicolon of an empty part of a for statement: 
+# for ( ; ; <here> ).
+sp_after_semi_for_empty                   = add   # ignore/add/remove/force
+
+# Add or remove space before '[' (except '[]')
+sp_before_square                          = ignore   # ignore/add/remove/force
+
+# Add or remove space before '[]', as in 'byte []'
+sp_before_squares                         = ignore   # ignore/add/remove/force
+
+# Add or remove space inside a non-empty '[' and ']'
+sp_inside_square                          = add   # ignore/add/remove/force
+
+# Add or remove space after ','
+sp_after_comma                            = add   # ignore/add/remove/force
+
+# Add or remove space before ','
+sp_before_comma                           = remove   # ignore/add/remove/force
+
+# Add or remove space between an open paren and comma: '(,' vs '( ,'
+sp_paren_comma                            = add    # ignore/add/remove/force
+
+# Add or remove space before the variadic '...' when preceded by a non-punctuator
+sp_before_ellipsis                        = ignore   # ignore/add/remove/force
+
+# Add or remove space after class ':'
+sp_after_class_colon                      = ignore   # ignore/add/remove/force
+
+# Add or remove space before class ':'
+sp_before_class_colon                     = ignore   # ignore/add/remove/force
+
+# Add or remove space after class constructor ':'
+sp_after_constr_colon                     = ignore   # ignore/add/remove/force
+
+# Add or remove space before class constructor ':'
+sp_before_constr_colon                    = ignore   # ignore/add/remove/force
+
+# Add or remove space before case ':'. Default=Remove
+sp_before_case_colon                      = remove   # ignore/add/remove/force
+
+# Add or remove space between 'operator' and operator sign
+sp_after_operator                         = ignore   # ignore/add/remove/force
+
+# Add or remove space between the operator symbol and the open paren, as in 
+# 'operator ++('
+sp_after_operator_sym                     = ignore   # ignore/add/remove/force
+
+# Add or remove space after C/D cast, i.e. 'cast(int)a' vs 'cast(int) a' or '(int)a' vs 
+# '(int) a'
+sp_after_cast                             = add   # ignore/add/remove/force
+
+# Add or remove spaces inside cast parens
+sp_inside_paren_cast                      = ignore   # ignore/add/remove/force
+
+# Add or remove space between the type and open paren in a C++ cast, i.e. 'int(exp)' 
+# vs 'int (exp)'
+sp_cpp_cast_paren                         = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'sizeof' and '('
+sp_sizeof_paren                           = remove   # ignore/add/remove/force
+
+# Add or remove space after the tag keyword (Pawn)
+sp_after_tag                              = ignore   # ignore/add/remove/force
+
+# Add or remove space inside enum '{' and '}'
+sp_inside_braces_enum                     = add   # ignore/add/remove/force
+
+# Add or remove space inside struct/union '{' and '}'
+sp_inside_braces_struct                   = add   # ignore/add/remove/force
+
+# Add or remove space inside '{' and '}'
+sp_inside_braces                          = add   # ignore/add/remove/force
+
+# Add or remove space inside '{}'
+sp_inside_braces_empty                    = ignore   # ignore/add/remove/force
+
+# Add or remove space between return type and function name
+# A minimum of 1 is forced except for pointer return types.
+sp_type_func                              = add   # ignore/add/remove/force
+
+# Add or remove space between function name and '(' on function declaration
+sp_func_proto_paren                       = remove   # ignore/add/remove/force
+
+# Add or remove space between function name and '(' on function definition
+sp_func_def_paren                         = remove   # ignore/add/remove/force
+
+# Add or remove space inside empty function '()'
+sp_inside_fparens                         = remove   # ignore/add/remove/force
+
+# Add or remove space inside function '(' and ')'
+sp_inside_fparen                          = add   # ignore/add/remove/force
+
+# Add or remove space inside the first parens in the function type: 'void (*x)(...)'
+sp_inside_tparen                          = ignore   # ignore/add/remove/force
+
+# Add or remove between the parens in the function type: 'void (*x)(...)'
+sp_after_tparen_close                     = ignore   # ignore/add/remove/force
+
+# Add or remove space between ']' and '(' when part of a function call.
+# native yark[rect](a[rect])
+sp_square_fparen                          = ignore   # ignore/add/remove/force
+
+# Add or remove space between ')' and '{' of function
+sp_fparen_brace                           = add   # ignore/add/remove/force
+
+# Java: Add or remove space between ')' and '{{' of double brace initializer.
+sp_fparen_dbrace                          = ignore   # ignore/add/remove/force
+
+# Add or remove space between function name and '(' on function calls
+sp_func_call_paren                        = remove   # ignore/add/remove/force
+
+# Add or remove space between function name and '()' on function calls without 
+# parameters.
+# If set to 'ignore' (the default), sp_func_call_paren is used.
+sp_func_call_paren_empty                  = ignore   # ignore/add/remove/force
+
+# Add or remove space between the user function name and '(' on function calls
+# You need to set a keyword to be a user function, like this: 'set func_call_user _' 
+# in the config file.
+sp_func_call_user_paren                   = ignore   # ignore/add/remove/force
+
+# Add or remove space between a constructor/destructor and the open paren
+sp_func_class_paren                       = remove   # ignore/add/remove/force
+
+# Add or remove space between 'return' and '('
+sp_return_paren                           = add   # ignore/add/remove/force
+
+# Add or remove space between '__attribute__' and '('
+sp_attribute_paren                        = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'defined' and '(' in '#if defined (FOO)'
+sp_defined_paren                          = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'throw' and '(' in 'throw (something)'
+sp_throw_paren                            = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'throw' and anything other than '(' as in '@throw [...];'
+sp_after_throw                            = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'catch' and '(' in 'catch (something) { }'
+# If set to ignore, sp_before_sparen is used.
+sp_catch_paren                            = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'version' and '(' in 'version (something) { }' (D language)
+# If set to ignore, sp_before_sparen is used.
+sp_version_paren                          = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'scope' and '(' in 'scope (something) { }' (D language)
+# If set to ignore, sp_before_sparen is used.
+sp_scope_paren                            = ignore   # ignore/add/remove/force
+
+# Add or remove space between macro and value, ie '#define a 6'
+sp_macro                                  = add   # ignore/add/remove/force
+
+# Add or remove space between macro function ')' and value
+sp_macro_func                             = add   # ignore/add/remove/force
+
+# Add or remove space between 'else' and '{' if on the same line
+sp_else_brace                             = ignore   # ignore/add/remove/force
+
+# Add or remove space between '}' and 'else' if on the same line
+sp_brace_else                             = ignore   # ignore/add/remove/force
+
+# Add or remove space between '}' and the name of a typedef on the same line
+sp_brace_typedef                          = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'catch' and '{' if on the same line
+sp_catch_brace                            = ignore   # ignore/add/remove/force
+
+# Add or remove space between '}' and 'catch' if on the same line
+sp_brace_catch                            = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'finally' and '{' if on the same line
+sp_finally_brace                          = ignore   # ignore/add/remove/force
+
+# Add or remove space between '}' and 'finally' if on the same line
+sp_brace_finally                          = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'try' and '{' if on the same line
+sp_try_brace                              = ignore   # ignore/add/remove/force
+
+# Add or remove space between get/set and '{' if on the same line
+sp_getset_brace                           = ignore   # ignore/add/remove/force
+
+# Add or remove space between a variable and '{' for C++ uniform initialization
+sp_word_brace                             = add      # ignore/add/remove/force
+
+# Add or remove space between a variable and '{' for a namespace
+sp_word_brace_ns                          = add      # ignore/add/remove/force
+
+# Add or remove space before the '::' operator
+sp_before_dc                              = ignore   # ignore/add/remove/force
+
+# Add or remove space after the '::' operator
+sp_after_dc                               = ignore   # ignore/add/remove/force
+
+# Add or remove around the D named array initializer ':' operator
+sp_d_array_colon                          = ignore   # ignore/add/remove/force
+
+# Add or remove space after the '!' (not) operator. Default=Remove
+sp_not                                    = remove   # ignore/add/remove/force
+
+# Add or remove space after the '~' (invert) operator. Default=Remove
+sp_inv                                    = remove   # ignore/add/remove/force
+
+# Add or remove space after the '&' (address-of) operator. Default=Remove
+# This does not affect the spacing after a '&' that is part of a type.
+sp_addr                                   = remove   # ignore/add/remove/force
+
+# Add or remove space around the '.' or '->' operators. Default=Remove
+sp_member                                 = remove   # ignore/add/remove/force
+
+# Add or remove space after the '*' (dereference) operator. Default=Remove
+# This does not affect the spacing after a '*' that is part of a type.
+sp_deref                                  = remove   # ignore/add/remove/force
+
+# Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'. Default=Remove
+sp_sign                                   = remove   # ignore/add/remove/force
+
+# Add or remove space before or after '++' and '--', as in '(--x)' or 'y++;'. Default=Remove
+sp_incdec                                 = remove   # ignore/add/remove/force
+
+# Add or remove space before a backslash-newline at the end of a line. Default=Add
+sp_before_nl_cont                         = add      # ignore/add/remove/force
+
+# Add or remove space after the scope '+' or '-', as in '-(void) foo;' or '+(int) bar;'
+sp_after_oc_scope                         = ignore   # ignore/add/remove/force
+
+# Add or remove space after the colon in message specs
+# '-(int) f:(int) x;' vs '-(int) f: (int) x;'
+sp_after_oc_colon                         = ignore   # ignore/add/remove/force
+
+# Add or remove space before the colon in message specs
+# '-(int) f: (int) x;' vs '-(int) f : (int) x;'
+sp_before_oc_colon                        = ignore   # ignore/add/remove/force
+
+# Add or remove space after the colon in immutable dictionary expression
+# 'NSDictionary *test = @{@"foo" :@"bar"};'
+sp_after_oc_dict_colon                    = ignore   # ignore/add/remove/force
+
+# Add or remove space before the colon in immutable dictionary expression
+# 'NSDictionary *test = @{@"foo" :@"bar"};'
+sp_before_oc_dict_colon                   = ignore   # ignore/add/remove/force
+
+# Add or remove space after the colon in message specs
+# '[object setValue:1];' vs '[object setValue: 1];'
+sp_after_send_oc_colon                    = ignore   # ignore/add/remove/force
+
+# Add or remove space before the colon in message specs
+# '[object setValue:1];' vs '[object setValue :1];'
+sp_before_send_oc_colon                   = ignore   # ignore/add/remove/force
+
+# Add or remove space after the (type) in message specs
+# '-(int)f: (int) x;' vs '-(int)f: (int)x;'
+sp_after_oc_type                          = ignore   # ignore/add/remove/force
+
+# Add or remove space after the first (type) in message specs
+# '-(int) f:(int)x;' vs '-(int)f:(int)x;'
+sp_after_oc_return_type                   = ignore   # ignore/add/remove/force
+
+# Add or remove space between '@selector' and '('
+# '@selector(msgName)' vs '@selector (msgName)'
+# Also applies to @protocol() constructs
+sp_after_oc_at_sel                        = ignore   # ignore/add/remove/force
+
+# Add or remove space between '@selector(x)' and the following word
+# '@selector(foo) a:' vs '@selector(foo)a:'
+sp_after_oc_at_sel_parens                 = ignore   # ignore/add/remove/force
+
+# Add or remove space inside '@selector' parens
+# '@selector(foo)' vs '@selector( foo )'
+# Also applies to @protocol() constructs
+sp_inside_oc_at_sel_parens                = ignore   # ignore/add/remove/force
+
+# Add or remove space before a block pointer caret
+# '^int (int arg){...}' vs. ' ^int (int arg){...}'
+sp_before_oc_block_caret                  = ignore   # ignore/add/remove/force
+
+# Add or remove space after a block pointer caret
+# '^int (int arg){...}' vs. '^ int (int arg){...}'
+sp_after_oc_block_caret                   = ignore   # ignore/add/remove/force
+
+# Add or remove space between the receiver and selector in a message.
+# '[receiver selector ...]'
+sp_after_oc_msg_receiver                  = ignore   # ignore/add/remove/force
+
+# Add or remove space after @property.
+sp_after_oc_property                      = ignore   # ignore/add/remove/force
+
+# Add or remove space around the ':' in 'b ? t : f'
+sp_cond_colon                             = ignore   # ignore/add/remove/force
+
+# Add or remove space before the ':' in 'b ? t : f'. Overrides sp_cond_colon.
+sp_cond_colon_before                      = ignore   # ignore/add/remove/force
+
+# Add or remove space after the ':' in 'b ? t : f'. Overrides sp_cond_colon.
+sp_cond_colon_after                       = ignore   # ignore/add/remove/force
+
+# Add or remove space around the '?' in 'b ? t : f'
+sp_cond_question                          = ignore   # ignore/add/remove/force
+
+# Add or remove space before the '?' in 'b ? t : f'. Overrides sp_cond_question.
+sp_cond_question_before                   = ignore   # ignore/add/remove/force
+
+# Add or remove space after the '?' in 'b ? t : f'. Overrides sp_cond_question.
+sp_cond_question_after                    = ignore   # ignore/add/remove/force
+
+# In the abbreviated ternary form (a ?: b), add/remove space between ? and :.'. 
+# Overrides all other sp_cond_* options.
+sp_cond_ternary_short                     = ignore   # ignore/add/remove/force
+
+# Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make sense here.
+sp_case_label                             = ignore   # ignore/add/remove/force
+
+# Control the space around the D '..' operator.
+sp_range                                  = ignore   # ignore/add/remove/force
+
+# Control the spacing after ':' in 'for (TYPE VAR : EXPR)' (Java)
+sp_after_for_colon                        = add   # ignore/add/remove/force
+
+# Control the spacing before ':' in 'for (TYPE VAR : EXPR)' (Java)
+sp_before_for_colon                       = add   # ignore/add/remove/force
+
+# Control the spacing in 'extern (C)' (D)
+sp_extern_paren                           = ignore   # ignore/add/remove/force
+
+# Control the space after the opening of a C++ comment '// A' vs '//A'
+sp_cmt_cpp_start                          = ignore   # ignore/add/remove/force
+
+# Controls the spaces between #else or #endif and a trailing comment
+sp_endif_cmt                              = ignore   # ignore/add/remove/force
+
+# Controls the spaces after 'new', 'delete', and 'delete[]'
+sp_after_new                              = ignore   # ignore/add/remove/force
+
+# Controls the spaces before a trailing or embedded comment
+sp_before_tr_emb_cmt                      = ignore   # ignore/add/remove/force
+
+# Number of spaces before a trailing or embedded comment
+sp_num_before_tr_emb_cmt                  = 0        # number
+
+# Control space between a Java annotation and the open paren.
+sp_annotation_paren                       = ignore   # ignore/add/remove/force
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
+# Code alignment (not left column spaces/tabs)
+# ####################################################################################################
+
+# Whether to keep non-indenting tabs
+align_keep_tabs                           = false    # false/true
+
+# Whether to use tabs for aligning
+align_with_tabs                           = false    # false/true
+
+# Whether to bump out to the next tab when aligning
+# always align on tabstops
+align_on_tabstop                          = false    # false/true
+
+# Whether to left-align numbers
+align_number_left                         = true    # false/true
+
+# Whether to keep whitespace not required for alignment.
+align_keep_extra_space                    = false    # false/true
+
+# Align variable definitions in prototypes and functions
+align_func_params                         = false    # false/true
+
+# Align parameters in single-line functions that have the same name.
+# The function names must already be aligned with each other.
+align_same_func_call_params               = false    # false/true
+
+# The span for aligning variable definitions (0=don't align)
+# align variable defs on variable (span for regular stuff)
+align_var_def_span                        = 1        # number
+
+# How to align the star in variable definitions.
+#  0=Part of the type     'void *   foo;'
+#  1=Part of the variable 'void     *foo;'
+#  2=Dangling             'void    *foo;'
+# the star is part of the variable name
+align_var_def_star_style                  = 1        # number
+
+# How to align the '&' in variable definitions.
+#  0=Part of the type
+#  1=Part of the variable
+#  2=Dangling
+align_var_def_amp_style                   = 0        # number
+
+# The threshold for aligning variable definitions (0=no limit)
+align_var_def_thresh                      = 0        # number
+
+# The gap for aligning variable definitions
+align_var_def_gap                         = 0        # number
+
+# Whether to align the colon in struct bit fields
+align_var_def_colon                       = false    # false/true
+
+# Whether to align any attribute after the variable name
+align_var_def_attribute                   = false    # false/true
+
+# Whether to align inline struct/enum/union variable definitions
+align_var_def_inline                      = true    # false/true
+
+# The span for aligning on '=' in assignments (0=don't align)
+align_assign_span                         = 1        # number
+
+# The threshold for aligning on '=' in assignments (0=no limit)
+align_assign_thresh                       = 0        # number
+
+# The span for aligning on '=' in enums (0=don't align)
+# align the '=' in enums
+align_enum_equ_span                       = 1        # number
+
+# The threshold for aligning on '=' in enums (0=no limit)
+align_enum_equ_thresh                     = 0        # number
+
+# The span for aligning struct/union (0=don't align)
+align_var_struct_span                     = 1        # number
+
+# The threshold for aligning struct/union member definitions (0=no limit)
+align_var_struct_thresh                   = 0        # number
+
+# The gap for aligning struct/union member definitions
+align_var_struct_gap                      = 0        # number
+
+# The span for aligning struct initializer values (0=don't align)
+align_struct_init_span                    = 1        # number
+
+# The minimum space between the type and the synonym of a typedef
+align_typedef_gap                         = 1        # number
+
+# The span for aligning single-line typedefs (0=don't align)
+align_typedef_span                        = 1        # number
+
+# How to align typedef'd functions with other typedefs
+# 0: Don't mix them at all
+# 1: align the open paren with the types
+# 2: align the function type name with the other type names
+align_typedef_func                        = 0        # number
+
+# Controls the positioning of the '*' in typedefs. Just try it.
+# 0: Align on typedef type, ignore '*'
+# 1: The '*' is part of type name: typedef int  *pint;
+# 2: The '*' is part of the type, but dangling: typedef int *pint;
+align_typedef_star_style                  = 1        # number
+
+# Controls the positioning of the '&' in typedefs. Just try it.
+# 0: Align on typedef type, ignore '&'
+# 1: The '&' is part of type name: typedef int  &pint;
+# 2: The '&' is part of the type, but dangling: typedef int &pint;
+align_typedef_amp_style                   = 0        # number
+
+# The span for aligning comments that end lines (0=don't align)
+align_right_cmt_span                      = 0        # number
+
+# If aligning comments, mix with comments after '}' and #endif with less than 3 
+# spaces before the comment
+align_right_cmt_mix                       = false    # false/true
+
+# If a trailing comment is more than this number of columns away from the text it 
+# follows, it will qualify for being aligned. This has to be > 0 to do anything.
+align_right_cmt_gap                       = 0        # number
+
+# Align trailing comment at or beyond column N; 'pulls in' comments as a bonus 
+# side effect (0=ignore)
+align_right_cmt_at_col                    = 0        # number
+
+# The span for aligning function prototypes (0=don't align)
+align_func_proto_span                     = 1        # number
+
+# Minimum gap between the return type and the function name.
+align_func_proto_gap                      = 0        # number
+
+# Align function protos on the 'operator' keyword instead of what follows
+align_on_operator                         = false    # false/true
+
+# Whether to mix aligning prototype and variable declarations.
+# If true, align_var_def_XXX options are used instead of align_func_proto_XXX 
+# options.
+align_mix_var_proto                       = false    # false/true
+
+# Align single-line functions with function prototypes, uses align_func_proto_span
+align_single_line_func                    = false    # false/true
+
+# Aligning the open brace of single-line functions.
+# Requires align_single_line_func=true, uses align_func_proto_span
+align_single_line_brace                   = false    # false/true
+
+# Gap for align_single_line_brace.
+align_single_line_brace_gap               = 0        # number
+
+# The span for aligning ObjC msg spec (0=don't align)
+align_oc_msg_spec_span                    = 0        # number
+
+# Whether to align macros wrapped with a backslash and a newline.
+# This will not work right if the macro contains a multi-line comment.
+# align the back-slash \n combo (macros)
+align_nl_cont                             = false    # false/true
+
+# # Align macro functions and variables together
+align_pp_define_together                  = false    # false/true
+
+# The minimum space between label and value of a preprocessor define
+# min space between define label and value "#define a <---> 16"
+align_pp_define_gap                       = 1        # number
+
+# The span for aligning on '#define' bodies (0=don't align, other=number of lines 
+# including comments between blocks)
+align_pp_define_span                      = 1        # number
+
+# Align lines that start with '<<' with previous '<<'. Default=true
+align_left_shift                          = true     # false/true
+
+# Span for aligning parameters in an Obj-C message call on the ':' (0=don't align)
+align_oc_msg_colon_span                   = 0        # number
+
+# If true, always align with the first parameter, even if it is too short.
+align_oc_msg_colon_first                  = false    # false/true
+
+# Aligning parameters in an Obj-C '+' or '-' declaration on the ':'
+align_oc_decl_colon                       = false    # false/true
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
+# Newline adding and removing options
+# ####################################################################################################
+
+# Whether to collapse empty blocks between '{' and '}'
+nl_collapse_empty_body                    = false    # false/true
+
+# Don't split one-line braced assignments - 'foo_t f = { 1, 2 };'
+nl_assign_leave_one_liners                = false    # false/true
+
+# Don't split one-line braced statements inside a class xx { } body
+nl_class_leave_one_liners                 = false    # false/true
+
+# Don't split one-line enums: 'enum foo { BAR = 15 };'
+nl_enum_leave_one_liners                  = false    # false/true
+
+# Don't split one-line get or set functions
+nl_getset_leave_one_liners                = false    # false/true
+
+# Don't split one-line function definitions - 'int foo() { return 0; }'
+nl_func_leave_one_liners                  = false    # false/true
+
+# Don't split one-line C++11 lambdas - '[]() { return 0; }'
+nl_cpp_lambda_leave_one_liners            = false    # false/true
+
+# Don't split one-line if/else statements - 'if(a) b++;'
+nl_if_leave_one_liners                    = false    # false/true
+
+# Don't split one-line OC messages
+nl_oc_msg_leave_one_liner                 = false    # false/true
+
+# Add or remove newlines at the start of the file
+nl_start_of_file                          = ignore   # ignore/add/remove/force
+
+# The number of newlines at the start of the file (only used if nl_start_of_file is 
+# 'add' or 'force'
+nl_start_of_file_min                      = 0        # number
+
+# Add or remove newline at the end of the file
+nl_end_of_file                            = add   # ignore/add/remove/force
+
+# The number of newlines at the end of the file (only used if nl_end_of_file is 
+# 'add' or 'force')
+nl_end_of_file_min                        = 2        # number
+
+# Add or remove newline between '=' and '{'
+nl_assign_brace                           = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '=' and '[' (D only)
+nl_assign_square                          = ignore   # ignore/add/remove/force
+
+# Add or remove newline after '= [' (D only). Will also affect the newline before the ']'
+nl_after_square_assign                    = ignore   # ignore/add/remove/force
+
+# The number of blank lines after a block of variable definitions at the top of a 
+# function body
+# 0 = No change (default)
+nl_func_var_def_blk                       = 0        # number
+
+# The number of newlines before a block of typedefs
+# 0 = No change (default)
+nl_typedef_blk_start                      = 0        # number
+
+# The number of newlines after a block of typedefs
+# 0 = No change (default)
+nl_typedef_blk_end                        = 0        # number
+
+# The maximum consecutive newlines within a block of typedefs
+# 0 = No change (default)
+nl_typedef_blk_in                         = 0        # number
+
+# The number of newlines before a block of variable definitions not at the top of 
+# a function body
+# 0 = No change (default)
+nl_var_def_blk_start                      = 0        # number
+
+# The number of newlines after a block of variable definitions not at the top of 
+# a function body
+# 0 = No change (default)
+nl_var_def_blk_end                        = 0        # number
+
+# The maximum consecutive newlines within a block of variable definitions
+# 0 = No change (default)
+nl_var_def_blk_in                         = 0        # number
+
+# Add or remove newline between a function call's ')' and '{', as in:
+# list_for_each(item, &list) { }
+nl_fcall_brace                            = force   # ignore/add/remove/force
+
+# Add or remove newline between 'enum' and '{'
+nl_enum_brace                             = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'struct and '{'
+nl_struct_brace                           = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'union' and '{'
+nl_union_brace                            = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'if' and '{'
+nl_if_brace                               = force   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'else'
+nl_brace_else                             = force   # ignore/add/remove/force
+
+# Add or remove newline between 'else if' and '{'
+# If set to ignore, nl_if_brace is used instead
+nl_elseif_brace                           = force   # ignore/add/remove/force
+
+# Add or remove newline between 'else' and '{'
+nl_else_brace                             = force   # ignore/add/remove/force
+
+# Add or remove newline between 'else' and 'if'
+nl_else_if                                = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'finally'
+nl_brace_finally                          = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'finally' and '{'
+nl_finally_brace                          = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'try' and '{'
+nl_try_brace                              = ignore   # ignore/add/remove/force
+
+# Add or remove newline between get/set and '{'
+nl_getset_brace                           = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'for' and '{'
+nl_for_brace                              = force   # ignore/add/remove/force
+
+# Add or remove newline between 'catch' and '{'
+nl_catch_brace                            = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'catch'
+nl_brace_catch                            = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '}' and ']'
+nl_brace_square                           = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '}' and ')' in a function invocation
+nl_brace_fparen                           = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'while' and '{'
+nl_while_brace                            = force   # ignore/add/remove/force
+
+# Add or remove newline between 'scope (x)' and '{' (D)
+nl_scope_brace                            = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'unittest' and '{' (D)
+nl_unittest_brace                         = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'version (x)' and '{' (D)
+nl_version_brace                          = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'using' and '{'
+nl_using_brace                            = ignore   # ignore/add/remove/force
+
+# Add or remove newline between two open or close braces.
+# Due to general newline/brace handling, REMOVE may not work.
+nl_brace_brace                            = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'do' and '{'
+nl_do_brace                               = force   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'while' of 'do' statement
+nl_brace_while                            = force   # ignore/add/remove/force
+
+# Add or remove newline between 'switch' and '{'
+nl_switch_brace                           = force   # ignore/add/remove/force
+
+# Add a newline between ')' and '{' if the ')' is on a different line than the if/for/etc.
+# Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch, and 
+# nl_catch_brace.
+nl_multi_line_cond                        = true    # false/true
+
+# Force a newline in a define after the macro name for multi-line defines.
+nl_multi_line_define                      = false    # false/true
+
+# Whether to put a newline before 'case' statement
+nl_before_case                            = false    # false/true
+
+# Add or remove newline between ')' and 'throw'
+nl_before_throw                           = ignore   # ignore/add/remove/force
+
+# Whether to put a newline after 'case' statement
+nl_after_case                             = false    # false/true
+
+# Add or remove a newline between a case ':' and '{'. Overrides nl_after_case.
+nl_case_colon_brace                       = force   # ignore/add/remove/force
+
+# Newline between namespace and {
+nl_namespace_brace                        = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'template<>' and whatever follows.
+nl_template_class                         = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'class' and '{'
+nl_class_brace                            = ignore   # ignore/add/remove/force
+
+# Add or remove newline after each ',' in the class base list
+nl_class_init_args                        = ignore   # ignore/add/remove/force
+
+# Add or remove newline after each ',' in the constructor member initialization
+nl_constr_init_args                       = ignore   # ignore/add/remove/force
+
+# Add or remove newline between return type and function name in a function definition
+nl_func_type_name                         = ignore   # ignore/add/remove/force
+
+# Add or remove newline between return type and function name inside a class {}
+# Uses nl_func_type_name or nl_func_proto_type_name if set to ignore.
+nl_func_type_name_class                   = ignore   # ignore/add/remove/force
+
+# Add or remove newline between function scope and name in a definition
+# Controls the newline after '::' in 'void A::f() { }'
+nl_func_scope_name                        = ignore   # ignore/add/remove/force
+
+# Add or remove newline between return type and function name in a prototype
+nl_func_proto_type_name                   = ignore   # ignore/add/remove/force
+
+# Add or remove newline between a function name and the opening '('
+nl_func_paren                             = ignore   # ignore/add/remove/force
+
+# Add or remove newline between a function name and the opening '(' in the definition
+nl_func_def_paren                         = ignore   # ignore/add/remove/force
+
+# Add or remove newline after '(' in a function declaration
+nl_func_decl_start                        = ignore   # ignore/add/remove/force
+
+# Add or remove newline after '(' in a function definition
+nl_func_def_start                         = ignore   # ignore/add/remove/force
+
+# Overrides nl_func_decl_start when there is only one parameter.
+nl_func_decl_start_single                 = ignore   # ignore/add/remove/force
+
+# Overrides nl_func_def_start when there is only one parameter.
+nl_func_def_start_single                  = ignore   # ignore/add/remove/force
+
+# Add or remove newline after each ',' in a function declaration
+nl_func_decl_args                         = ignore   # ignore/add/remove/force
+
+# Add or remove newline after each ',' in a function definition
+nl_func_def_args                          = ignore   # ignore/add/remove/force
+
+# Add or remove newline before the ')' in a function declaration
+nl_func_decl_end                          = remove   # ignore/add/remove/force
+
+# Add or remove newline before the ')' in a function definition
+nl_func_def_end                           = remove   # ignore/add/remove/force
+
+# Overrides nl_func_decl_end when there is only one parameter.
+nl_func_decl_end_single                   = ignore   # ignore/add/remove/force
+
+# Overrides nl_func_def_end when there is only one parameter.
+nl_func_def_end_single                    = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '()' in a function declaration.
+nl_func_decl_empty                        = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '()' in a function definition.
+nl_func_def_empty                         = ignore   # ignore/add/remove/force
+
+# Whether to put each OC message parameter on a separate line
+# See nl_oc_msg_leave_one_liner
+nl_oc_msg_args                            = false    # false/true
+
+# Add or remove newline between function signature and '{'
+# "int foo() {" vs "int foo()\n{"
+nl_fdef_brace                             = force   # ignore/add/remove/force
+
+# Add or remove newline between C++11 lambda signature and '{'
+nl_cpp_ldef_brace                         = ignore   # ignore/add/remove/force
+
+# Add or remove a newline between the return keyword and return expression.
+nl_return_expr                            = ignore   # ignore/add/remove/force
+
+# Whether to put a newline after semicolons, except in 'for' statements
+nl_after_semicolon                        = false    # false/true
+
+# Java: Control the newline between the ')' and '{{' of the double brace initializer.
+nl_paren_dbrace_open                      = ignore   # ignore/add/remove/force
+
+# Whether to put a newline after brace open.
+# This also adds a newline before the matching brace close.
+nl_after_brace_open                       = false    # false/true
+
+# If nl_after_brace_open and nl_after_brace_open_cmt are true, a newline is
+# placed between the open brace and a trailing single-line comment.
+nl_after_brace_open_cmt                   = false    # false/true
+
+# Whether to put a newline after a virtual brace open with a non-empty body.
+# These occur in un-braced if/while/do/for statement bodies.
+nl_after_vbrace_open                      = false    # false/true
+
+# Whether to put a newline after a virtual brace open with an empty body.
+# These occur in un-braced if/while/do/for statement bodies.
+nl_after_vbrace_open_empty                = false    # false/true
+
+# Whether to put a newline after a brace close.
+# Does not apply if followed by a necessary ';'.
+nl_after_brace_close                      = false    # false/true
+
+# Whether to put a newline after a virtual brace close.
+# Would add a newline before return in: 'if (foo) a++; return;'
+nl_after_vbrace_close                     = true    # false/true
+
+# Control the newline between the close brace and 'b' in: 'struct { int a; } b;'
+# Affects enums, unions, and structures. If set to ignore, uses nl_after_brace_close
+nl_brace_struct_var                       = ignore   # ignore/add/remove/force
+
+# Whether to alter newlines in '#define' macros
+nl_define_macro                           = false    # false/true
+
+# Whether to not put blanks after '#ifxx', '#elxx', or before '#endif'
+# No blanks after #ifxx, #elxx, or before #endif TRUE/F
+nl_squeeze_ifdef                          = true    # false/true
+
+# Add or remove blank line before 'if'
+nl_before_if                              = force   # ignore/add/remove/force
+
+# Add or remove blank line after 'if' statement
+nl_after_if                               = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'for'
+nl_before_for                             = force   # ignore/add/remove/force
+
+# Add or remove blank line after 'for' statement
+nl_after_for                              = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'while'
+nl_before_while                           = force   # ignore/add/remove/force
+
+# Add or remove blank line after 'while' statement
+nl_after_while                            = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'switch'
+nl_before_switch                          = force   # ignore/add/remove/force
+
+# Add or remove blank line after 'switch' statement
+nl_after_switch                           = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'do'
+nl_before_do                              = force   # ignore/add/remove/force
+
+# Add or remove blank line after 'do/while' statement
+nl_after_do                               = ignore   # ignore/add/remove/force
+
+# Whether to double-space commented-entries in struct/enum
+nl_ds_struct_enum_cmt                     = false    # false/true
+
+# Whether to double-space before the close brace of a struct/union/enum
+# (lower priority than 'eat_blanks_before_close_brace')
+nl_ds_struct_enum_close_brace             = false    # false/true
+
+# Add or remove a newline around a class colon.
+# Related to pos_class_colon, nl_class_init_args, and pos_class_comma.
+nl_class_colon                            = ignore   # ignore/add/remove/force
+
+# Add or remove a newline around a class constructor colon.
+# Related to pos_constr_colon, nl_constr_init_args, and pos_constr_comma.
+nl_constr_colon                           = ignore   # ignore/add/remove/force
+
+# Change simple unbraced if statements into a one-liner
+# 'if(b)\n i++;' => 'if(b) i++;'
+nl_create_if_one_liner                    = false    # false/true
+
+# Change simple unbraced for statements into a one-liner
+# 'for (i=0;i<5;i++)\n foo(i);' => 'for (i=0;i<5;i++) foo(i);'
+nl_create_for_one_liner                   = false    # false/true
+
+# Change simple unbraced while statements into a one-liner
+# 'while (i<5)\n foo(i++);' => 'while (i<5) foo(i++);'
+nl_create_while_one_liner                 = false    # false/true
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
+# Positioning options
+# ####################################################################################################
+
+# The position of arithmetic operators in wrapped expressions
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_arith                                 = ignore   
+
+# The position of assignment in wrapped expressions.
+# Do not affect '=' followed by '{'
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_assign                                = ignore   
+
+# The position of boolean operators in wrapped expressions
+# end=move &&/|| to EOL ignore=gnore, start=move to SOL
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_bool                                  = lead_force   
+
+# The position of comparison operators in wrapped expressions
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_compare                               = ignore   
+
+# The position of conditional (b ? t : f) operators in wrapped expressions
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_conditional                           = ignore   
+
+# The position of the comma in wrapped expressions
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_comma                                 = ignore   
+
+# The position of the comma in the class base list
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_class_comma                           = ignore   
+
+# The position of the comma in the constructor initialization list
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_constr_comma                          = ignore   
+
+# The position of colons between class and base class list
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_class_colon                           = ignore   
+
+# The position of colons between constructor and member initialization
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_constr_colon                          = ignore   
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
+# Line Splitting options
+# ####################################################################################################
+
+# Try to limit code width to N number of columns
+code_width                                = 0        # number
+
+# Whether to fully split long 'for' statements at semi-colons
+ls_for_split_full                         = true    # false/true
+
+# Whether to fully split long function protos/calls at commas
+ls_func_split_full                        = false    # false/true
+
+# Whether to split lines as close to code_width as possible and ignore some groupings
+ls_code_width                             = false    # false/true
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
+# Blank line options
+# ####################################################################################################
+
+# The maximum consecutive newlines
+# Maximum consecutive newlines, 3=2 lines, 0=disabled
+nl_max                                    = 3        # number
+
+# The number of newlines after a function prototype, if followed by another 
+# function prototype
+nl_after_func_proto                       = 3        # number
+
+# The number of newlines after a function prototype, if not followed by another 
+# function prototype
+nl_after_func_proto_group                 = 3        # number
+
+# The number of newlines after '}' of a multi-line function body
+nl_after_func_body                        = 2        # number
+
+# The number of newlines after '}' of a multi-line function body in a class declaration
+nl_after_func_body_class                  = 0        # number
+
+# The number of newlines after '}' of a single line function body
+nl_after_func_body_one_liner              = 0        # number
+
+# The minimum number of newlines before a multi-line comment.
+# Doesn't apply if after a brace open or another multi-line comment.
+# Before a block comment (stand-alone comment-multi), except after brace open
+nl_before_block_comment                   = 3        # number
+
+# The minimum number of newlines before a single-line C comment.
+# Doesn't apply if after a brace open or other single-line C comments.
+nl_before_c_comment                       = 0        # number
+
+# The minimum number of newlines before a CPP comment.
+# Doesn't apply if after a brace open or other CPP comments.
+nl_before_cpp_comment                     = 0        # number
+
+# Whether to force a newline after a multi-line comment.
+nl_after_multiline_comment                = false    # false/true
+
+# The number of newlines after '}' or ';' of a struct/enum/union definition
+nl_after_struct                           = 0        # number
+
+# The number of newlines after '}' or ';' of a class definition
+nl_after_class                            = 0        # number
+
+# The number of newlines before a 'private:', 'public:', 'protected:', 'signals:', or 'slots:' label.
+# Will not change the newline count if after a brace open.
+# 0 = No change.
+nl_before_access_spec                     = 0        # number
+
+# The number of newlines after a 'private:', 'public:', 'protected:', 'signals:', or 'slots:' label.
+# 0 = No change.
+nl_after_access_spec                      = 0        # number
+
+# The number of newlines between a function def and the function comment.
+# 0 = No change.
+nl_comment_func_def                       = 0        # number
+
+# The number of newlines after a try-catch-finally block that isn't followed by a brace close.
+# 0 = No change.
+nl_after_try_catch_finally                = 0        # number
+
+# The number of newlines before and after a property, indexer or event decl.
+# 0 = No change.
+nl_around_cs_property                     = 0        # number
+
+# The number of newlines between the get/set/add/remove handlers in C#.
+# 0 = No change.
+nl_between_get_set                        = 0        # number
+
+# Add or remove newline between C# property and the '{'
+nl_property_brace                         = ignore   # ignore/add/remove/force
+
+# Whether to remove blank lines after '{'
+eat_blanks_after_open_brace               = true    # false/true
+
+# Whether to remove blank lines before '}'
+eat_blanks_before_close_brace             = true    # false/true
+
+# How aggressively to remove extra newlines not in preproc.
+# 0: No change
+# 1: Remove most newlines not handled by other config
+# 2: Remove all newlines and reformat completely by config
+nl_remove_extra_newlines                  = 0        # number
+
+# Whether to put a blank line before 'return' statements, unless after an open brace.
+nl_before_return                          = false    # false/true
+
+# Whether to put a blank line after 'return' statements, unless followed by a close brace.
+nl_after_return                           = false    # false/true
+
+# Whether to put a newline after a Java annotation statement.
+# Only affects annotations that are after a newline.
+nl_after_annotation                       = ignore   # ignore/add/remove/force
+
+# Controls the newline between two annotations.
+nl_between_annotation                     = ignore   # ignore/add/remove/force
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
+# Code modifying options (non-whitespace)
+# ####################################################################################################
+
+# Add or remove braces on single-line 'do' statement
+mod_full_brace_do                         = force   # ignore/add/remove/force
+
+# Add or remove braces on single-line 'for' statement
+mod_full_brace_for                        = force   # ignore/add/remove/force
+
+# Add or remove braces on single-line function definitions. (Pawn)
+mod_full_brace_function                   = force   # ignore/add/remove/force
+
+# Add or remove braces on single-line 'if' statement. Will not remove the braces 
+# if they contain an 'else'.
+mod_full_brace_if                         = force   # ignore/add/remove/force
+
+# Make all if/elseif/else statements in a chain be braced or not. Overrides 
+# mod_full_brace_if. # If any must be braced, they are all braced.  If all can be 
+# unbraced, then the braces are removed.
+mod_full_brace_if_chain                   = false    # false/true
+
+# Don't remove braces around statements that span N newlines
+# Max number of newlines to span w/o braces
+mod_full_brace_nl                         = 1        # number
+
+# Add or remove braces on single-line 'while' statement
+mod_full_brace_while                      = force   # ignore/add/remove/force
+
+# Add or remove braces on single-line 'using ()' statement
+mod_full_brace_using                      = ignore   # ignore/add/remove/force
+
+# Add or remove unnecessary paren on 'return' statement
+mod_paren_on_return                       = ignore   # ignore/add/remove/force
+
+# Whether to change optional semicolons to real semicolons
+mod_pawn_semicolon                        = false    # false/true
+
+# Add parens on 'while' and 'if' statement around bools
+mod_full_paren_if_bool                    = false    # false/true
+
+# Whether to remove superfluous semicolons
+mod_remove_extra_semicolon                = false    # false/true
+
+# If a function body exceeds the specified number of newlines and doesn't have a 
+# comment after
+# the close brace, a comment will be added.
+mod_add_long_function_closebrace_comment  = 0        # number
+
+# If a namespace body exceeds the specified number of newlines and doesn't have 
+# a comment after
+# the close brace, a comment will be added.
+mod_add_long_namespace_closebrace_comment = 0        # number
+
+# If a switch body exceeds the specified number of newlines and doesn't have a 
+# comment after
+# the close brace, a comment will be added.
+mod_add_long_switch_closebrace_comment    = 0        # number
+
+# If an #ifdef body exceeds the specified number of newlines and doesn't have a 
+# comment after
+# the #endif, a comment will be added.
+mod_add_long_ifdef_endif_comment          = 0        # number
+
+# If an #ifdef or #else body exceeds the specified number of newlines and doesn't 
+# have a comment after
+# the #else, a comment will be added.
+mod_add_long_ifdef_else_comment           = 0        # number
+
+# If TRUE, will sort consecutive single-line 'import' statements [Java, D]
+mod_sort_import                           = false    # false/true
+
+# If TRUE, will sort consecutive single-line 'using' statements [C#]
+mod_sort_using                            = false    # false/true
+
+# If TRUE, will sort consecutive single-line '#include' statements [C/C++] and 
+# '#import' statements [Obj-C]
+# This is generally a bad idea, as it may break your code.
+mod_sort_include                          = false    # false/true
+
+# If TRUE, it will move a 'break' that appears after a fully braced 'case' before the 
+# close brace.
+mod_move_case_break                       = false    # false/true
+
+# Will add or remove the braces around a fully braced case statement.
+# Will only remove the braces if there are no variable declarations in the block.
+mod_case_brace                            = ignore   # ignore/add/remove/force
+
+# If TRUE, it will remove a void 'return;' that appears as the last statement in a function.
+mod_remove_empty_return                   = false    # false/true
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
+# Comment modifications
+# ####################################################################################################
+
+# Try to wrap comments at cmt_width columns
+cmt_width                                 = 0        # number
+
+# Set the comment reflow mode (default: 0)
+# 0: no reflowing (apart from the line wrapping due to cmt_width)
+# 1: no touching at all
+# 2: full reflow
+cmt_reflow_mode                           = 0        # number
+
+# Whether to convert all tabs to spaces in comments. Default is to leave tabs inside 
+# comments alone, unless used for indenting.
+cmt_convert_tab_to_spaces                 = true    # false/true
+
+# If false, disable all multi-line comment changes, including cmt_width. keyword 
+# substitution, and leading chars.
+# Default is true.
+cmt_indent_multi                          = false     # false/true
+
+# Whether to group c-comments that look like they are in a block
+cmt_c_group                               = false    # false/true
+
+# Whether to put an empty '/*' on the first line of the combined c-comment
+cmt_c_nl_start                            = false    # false/true
+
+# Whether to put a newline before the closing '*/' of the combined c-comment
+cmt_c_nl_end                              = false    # false/true
+
+# Whether to group cpp-comments that look like they are in a block
+# If UO_cmt_cpp_to_c, try to group in one big C comment
+cmt_cpp_group                             = false    # false/true
+
+# Whether to put an empty '/*' on the first line of the combined cpp-comment
+# Put a blank /* at the start of a converted group
+cmt_cpp_nl_start                          = false    # false/true
+
+# Whether to put a newline before the closing '*/' of the combined cpp-comment
+cmt_cpp_nl_end                            = false    # false/true
+
+# Whether to change cpp-comments into c-comments
+cmt_cpp_to_c                              = false    # false/true
+
+# Whether to put a star on subsequent comment lines
+cmt_star_cont                             = false    # false/true
+
+# The number of spaces to insert at the start of subsequent comment lines
+cmt_sp_before_star_cont                   = 0        # number
+
+# The number of spaces to insert after the star on subsequent comment lines
+cmt_sp_after_star_cont                    = 0        # number
+
+# For multi-line comments with a '*' lead, remove leading spaces if the first and 
+# last lines of
+# the comment are the same length. Default=True
+cmt_multi_check_last                      = true     # false/true
+
+# The filename that contains text to insert at the head of a file if the file doesn't 
+# start with a C/C++ comment.
+# Will substitute $(filename) with the current file's name.
+cmt_insert_file_header                    = ""         # string
+
+# The filename that contains text to insert at the end of a file if the file doesn't end 
+# with a C/C++ comment.
+# Will substitute $(filename) with the current file's name.
+cmt_insert_file_footer                    = ""         # string
+
+# The filename that contains text to insert before a function implementation if the 
+# function isn't preceded with a C/C++ comment.
+# Will substitute $(function) with the function name and $(javaparam) with the 
+# javadoc @param and @return stuff.
+# Will also substitute $(fclass) with the class name: void CFoo::Bar() { ... }
+cmt_insert_func_header                    = ""         # string
+
+# The filename that contains text to insert before a class if the class isn't preceded 
+# with a C/C++ comment.
+# Will substitute $(class) with the class name.
+cmt_insert_class_header                   = ""         # string
+
+# The filename that contains text to insert before a Obj-C message specification if 
+# the method isn't preceded with a C/C++ comment.
+# Will substitute $(message) with the function name and $(javaparam) with the 
+# javadoc @param and @return stuff.
+cmt_insert_oc_msg_header                  = ""         # string
+
+# If a preprocessor is encountered when stepping backwards from a function name, then
+# this option decides whether the comment should be inserted.
+# Affects cmt_insert_oc_msg_header, cmt_insert_func_header and cmt_insert_class_header.
+cmt_insert_before_preproc                 = false    # false/true
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
+# Preprocessor options
+# ####################################################################################################
+
+# Control indent of preprocessors inside #if blocks at brace level 0 (file-level)
+pp_indent                                 = ignore   # ignore/add/remove/force
+
+# Whether to indent #if/#else/#endif at the brace level (true) or from column 1 (false)
+pp_indent_at_level                        = false    # false/true
+
+# Specifies the number of columns to indent preprocessors per level at brace level 
+# 0 (file-level).
+# If pp_indent_at_level=false, specifies the number of columns to indent 
+# preprocessors per level at brace level > 0 (function-level).
+# Default=1.
+pp_indent_count                           = 1        # number
+
+# Add or remove space after # based on pp_level of #if blocks
+pp_space                                  = ignore   # ignore/add/remove/force
+
+# Sets the number of spaces added with pp_space
+pp_space_count                            = 0        # number
+
+# The indent for #region and #endregion in C# and '#pragma region' in C/C++
+pp_indent_region                          = 0        # number
+
+# Whether to indent the code between #region and #endregion
+pp_region_indent_code                     = false    # false/true
+
+# If pp_indent_at_level=true, sets the indent for #if, #else, and #endif when not at 
+# file-level.
+# 0:  indent preprocessors using output_tab_size.
+# >0: column at which all preprocessors will be indented.
+pp_indent_if                              = 0        # number
+
+# Control whether to indent the code between #if, #else and #endif.
+pp_if_indent_code                         = false    # false/true
+
+# Whether to indent '#define' at the brace level (true) or from column 1 (false)
+pp_define_at_level                        = false    # false/true
+
+# You can force a token to be a type with the 'type' option.
+# Example:
+# type myfoo1 myfoo2
+#
+# You can create custom macro-based indentation using macro-open,
+# macro-else and macro-close.
+# Example:
+# macro-open  BEGIN_TEMPLATE_MESSAGE_MAP
+# macro-open  BEGIN_MESSAGE_MAP
+# macro-close END_MESSAGE_MAP
+#
+# You can assign any keyword to any type with the set option.
+# set func_call_user _ N_
+#
+# The full syntax description of all custom definition config entries
+# is shown below:
+#
+# define custom tokens as:
+# - embed whitespace in token using '' escape character, or
+#   put token in quotes
+# - these: ' " and ` are recognized as quote delimiters
+#
+# type token1 token2 token3 ...
+#             ^ optionally specify multiple tokens on a single line
+# define def_token output_token
+#                  ^ output_token is optional, then NULL is assumed
+# macro-open token
+# macro-close token
+# macro-else token
+# set id token1 token2 ...
+#               ^ optionally specify multiple tokens on a single line
+#     ^ id is one of the names in token_enum.h sans the CT_ prefix,
+#       e.g. PP_PRAGMA
+#
+# all tokens are separated by any mix of ',' commas, '=' equal signs
+# and whitespace (space, tab)
+#
+# You can add support for other file extensions using the 'file_ext' command.
+# The first arg is the language name used with the '-l' option.
+# The remaining args are file extensions, matched with 'endswith'.
+#   file_ext CPP .ch .cxx .cpp.in
+#

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -166,7 +166,14 @@ void register_options(void)
    unc_add_option("output_tab_size", UO_output_tab_size, AT_NUM,
                   "The size of tabs in the output (only used if align_with_tabs=true)", "", 1, 32);
    unc_add_option("string_escape_char", UO_string_escape_char, AT_NUM,
-                  "The ASCII value of the string escape char, usually 92 (\\) or 94 (^). (Pawn)", "", 0, 255);
+                  "The ASCII value of the string escape char, usually 92 (\\) or 94 (^). (Pawn)"
+                  "If 94 is selected, remove spaces only at the preprocessor macro functions\n"
+                  "declarations and ignore adding arithmetic expressions spaces at the macro\n"
+                  "function body. Ex: '#define COOL_MACRO(%1,%2)   ( %1 = %2 + 1 )' # instead of:\n"
+                  "'define COOL_MACRO( % 1 , % 2 )   ( % 1 = % 2 + 1 )', which is wrong.\n"
+                  "To accomplish it, this overrides sp_inside_paren, sp_after_comma and sp_arith\n"
+                  "only at the macro function declaration and body."
+                   "at the macro function declaration and body.", "", 0, 255);
    unc_add_option("string_escape_char2", UO_string_escape_char2, AT_NUM,
                   "Alternate string escape char for Pawn. Only works right before the quote char.", "", 0, 255);
    unc_add_option("string_replace_tab_chars", UO_string_replace_tab_chars, AT_BOOL,

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -169,8 +169,8 @@ void register_options(void)
                   "The ASCII value of the string escape char, usually 92 (\\) or 94 (^). (Pawn)"
                   "If 94 is selected, remove spaces only at the preprocessor macro functions\n"
                   "declarations and ignore adding arithmetic expressions spaces at the macro\n"
-                  "function body. Ex: '#define COOL_MACRO(%1,%2)   ( %1 = %2 + 1 )' # instead of:\n"
-                  "'define COOL_MACRO( % 1 , % 2 )   ( % 1 = % 2 + 1 )', which is wrong.\n"
+                  "function body. Ex: \'#define COOL_MACRO(%1,%2)   ( %1 = %2 + 1 )\' # instead of:\n"
+                  "\'define COOL_MACRO( % 1 , % 2 )   ( % 1 = % 2 + 1 )\', which is wrong.\n"
                   "To accomplish it, this overrides sp_inside_paren, sp_after_comma and sp_arith\n"
                   "only at the macro function declaration and body."
                    "at the macro function declaration and body.", "", 0, 255);

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -1317,8 +1317,8 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
       log_rule("ADD");
       return(AV_ADD);
    }
-   
-   /* "#define SXO(%1,%2) 1 < %1 - %2" vs "#define SEXO(%1,%2) 1 < % 1 - % 2" (wrong pawn syntax)*/
+
+   /* "#define SXO(%1,%2) 1 < %1 - %2" vs "#define SXO(%1,%2) 1 < % 1 - % 2" (wrong pawn syntax)*/
    if ( ( first->type == CT_ARITH) 
         && (second->type == CT_NUMBER )
         && ( first->flags & PCF_IN_PREPROC )
@@ -1327,6 +1327,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
       log_rule("string_escape_char");
       return AV_IGNORE;
    }
+
    if ((first->type == CT_ARITH) || (first->type == CT_CARET) ||
        (second->type == CT_ARITH) || (second->type == CT_CARET))
    {

--- a/tests/config/pawn_amxmodx.cfg
+++ b/tests/config/pawn_amxmodx.cfg
@@ -1,6 +1,10 @@
 # Uncrustify 0.61
 
 #
+# AMX Mod X style for Pawn
+#
+
+#
 # General options
 #
 
@@ -8,10 +12,10 @@
 newlines                                  = auto     # auto/lf/crlf/cr
 
 # The original size of tabs in the input
-input_tab_size                            = 8        # number
+input_tab_size                            = 4        # number
 
 # The size of tabs in the output (only used if align_with_tabs=true)
-output_tab_size                           = 8        # number
+output_tab_size                           = 4        # number
 
 # The ASCII value of the string escape char, usually 92 (\) or 94 (^). (Pawn)
 # If 94 is selected, remove spaces only at the preprocessor macro functions
@@ -20,58 +24,69 @@ output_tab_size                           = 8        # number
 # 'define COOL_MACRO( % 1 , % 2 )   ( % 1 = % 2 + 1 )', which is wrong.
 # To accomplish it, this overrides sp_inside_paren, sp_after_comma and sp_arith
 # only at the macro function declaration and body.
-string_escape_char                        = 92       # number
+string_escape_char                        = 94       # number
 
 # Alternate string escape char for Pawn. Only works right before the quote char.
 string_escape_char2                       = 0        # number
-
-# Replace tab characters found in string literals with the escape sequence \t instead.
-string_replace_tab_chars                  = false    # false/true
 
 # Allow interpreting '>=' and '>>=' as part of a template in 'void f(list<list<B>>=val);'.
 # If true (default), 'assert(x<0 && y>=3)' will be broken.
 # Improvements to template detection may make this option obsolete.
 tok_split_gte                             = false    # false/true
 
-# Override the default ' *INDENT-OFF*' in comments for disabling processing of part of the file.
-disable_processing_cmt                    = ""         # string
-
-# Override the default ' *INDENT-ON*' in comments for enabling processing of part of the file.
-enable_processing_cmt                     = ""         # string
-
 # Control what to do with the UTF-8 BOM (recommend 'remove')
 utf8_bom                                  = ignore   # ignore/add/remove/force
 
-# If the file contains bytes with values between 128 and 255, but is not UTF-8, then output as UTF-8
+# If the file contains bytes with values between 128 and 255, but is not UTF-8, 
+# then output as UTF-8
 utf8_byte                                 = false    # false/true
 
 # Force the output encoding to UTF-8
 utf8_force                                = false    # false/true
 
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
 # Indenting
-#
+# ####################################################################################################
 
 # The number of columns to indent per level.
 # Usually 2, 3, 4, or 8.
-indent_columns                            = 8        # number
+indent_columns                            = 4        # number
 
-# The continuation indent. If non-zero, this overrides the indent of '(' and '=' continuation indents.
-# For FreeBSD, this is set to 4. Negative value is absolute and not increased for each ( level
+# The continuation indent. If non-zero, this overrides the indent of '(' and '=' 
+# continuation indents. For FreeBSD, this is set to 4. Negative value is absolute 
+# and not increased for each ( level
 indent_continue                           = 0        # number
 
 # How to use tabs when indenting code
 # 0=spaces only
 # 1=indent with tabs to brace level, align with spaces
 # 2=indent and align with tabs, using spaces when not on a tabstop
-indent_with_tabs                          = 1        # number
+indent_with_tabs                          = 0        # number
 
 # Comments that are not a brace level are indented with tabs on a tabstop.
 # Requires indent_with_tabs=2. If false, will use spaces.
 indent_cmt_with_tabs                      = false    # false/true
 
 # Whether to indent strings broken by '\' so that they line up
-indent_align_string                       = false    # false/true
+indent_align_string                       = true    # false/true
 
 # The number of spaces to indent multi-line XML strings.
 # Requires indent_align_string=True
@@ -92,16 +107,18 @@ indent_braces_no_class                    = false    # false/true
 # Disabled indenting struct braces if indent_braces is true
 indent_braces_no_struct                   = false    # false/true
 
-# Indent based on the size of the brace parent, i.e. 'if' => 3 spaces, 'for' => 4 spaces, etc.
+# Indent based on the size of the brace parent, i.e. 'if' => 3 spaces, 'for' => 4 
+# spaces, etc.
 indent_brace_parent                       = false    # false/true
 
-# Indent based on the paren open instead of the brace open in '({\n', default is to indent by brace.
+# Indent based on the paren open instead of the brace open in '({\n', default is to 
+# indent by brace.
 indent_paren_open_brace                   = false    # false/true
 
 # Whether the 'namespace' body is indented
-indent_namespace                          = false    # false/true
+indent_namespace                          = true    # false/true
 
-# Only indent one namespace and no sub-namespaces.
+# Only indent one namespace and no sub-namepaces.
 # Requires indent_namespace=true.
 indent_namespace_single_indent            = false    # false/true
 
@@ -116,14 +133,10 @@ indent_namespace_limit                    = 0        # number
 indent_extern                             = false    # false/true
 
 # Whether the 'class' body is indented
-indent_class                              = false    # false/true
+indent_class                              = true    # false/true
 
 # Whether to indent the stuff after a leading base class colon
 indent_class_colon                        = false    # false/true
-
-# Indent based on a class colon instead of the stuff after the colon.
-# Requires indent_class_colon=true. Default=false
-indent_class_on_colon                     = false    # false/true
 
 # Whether to indent the stuff after a leading class initializer colon
 indent_constr_colon                       = false    # false/true
@@ -144,17 +157,13 @@ indent_var_def_blk                        = 0        # number
 # Indent continued variable declarations instead of aligning.
 indent_var_def_cont                       = false    # false/true
 
-# Indent continued shift expressions ('<<' and '>>') instead of aligning.
-# Turn align_left_shift off when enabling this.
-indent_shift                              = false    # false/true
-
 # True:  force indentation of function definition to start in column 1
 # False: use the default behavior
 indent_func_def_force_col1                = false    # false/true
 
 # True:  indent continued function call parameters one indent level
 # False: align parameters under the open paren
-indent_func_call_param                    = false    # false/true
+indent_func_call_param                    = true    # false/true
 
 # Same as indent_func_call_param, but for function defs
 indent_func_def_param                     = false    # false/true
@@ -172,7 +181,7 @@ indent_func_ctor_var_param                = false    # false/true
 indent_template_param                     = false    # false/true
 
 # Double the indent for indent_func_xxx_param options
-indent_func_param_double                  = false    # false/true
+indent_func_param_double                  = true    # false/true
 
 # Indentation column for standalone 'const' function decl/proto qualifier
 indent_func_const                         = 0        # number
@@ -182,7 +191,7 @@ indent_func_throw                         = 0        # number
 
 # The number of spaces to indent a continued '->' or '.'
 # Usually set to 0, 1, or indent_columns.
-indent_member                             = 0        # number
+indent_member                             = indent_columns        # number
 
 # Spaces to indent single line ('//') comments on lines before code
 indent_sing_line_comments                 = 0        # number
@@ -193,7 +202,7 @@ indent_relative_single_line_comments      = false    # false/true
 
 # Spaces to indent 'case' from 'switch'
 # Usually 0 or indent_columns.
-indent_switch_case                        = 0        # number
+indent_switch_case                        = indent_columns        # number
 
 # Spaces to shift the 'case' line, without affecting any other lines
 # Usually 0.
@@ -210,7 +219,7 @@ indent_col1_comment                       = false    # false/true
 # How to indent goto labels
 #  >0 : absolute column where 1 is the leftmost column
 #  <=0 : subtract from brace indent
-indent_label                              = 1        # number
+indent_label                              = 0        # number
 
 # Same as indent_label, but for access specifiers that are followed by a colon
 indent_access_spec                        = 1        # number
@@ -219,7 +228,8 @@ indent_access_spec                        = 1        # number
 # If set, this option forces 'indent_access_spec=0'
 indent_access_spec_body                   = false    # false/true
 
-# If an open paren is followed by a newline, indent the next line so that it lines up after the open paren (not recommended)
+# If an open paren is followed by a newline, indent the next line so that it lines up 
+# after the open paren (not recommended)
 indent_paren_nl                           = false    # false/true
 
 # Controls the indent of a close paren after a newline.
@@ -228,16 +238,20 @@ indent_paren_nl                           = false    # false/true
 # 2: Indent to the brace level
 indent_paren_close                        = 0        # number
 
-# Controls the indent of a comma when inside a paren.If TRUE, aligns under the open paren
+# Controls the indent of a comma when inside a paren. If TRUE, aligns under the 
+# open paren
 indent_comma_paren                        = false    # false/true
 
-# Controls the indent of a BOOL operator when inside a paren.If TRUE, aligns under the open paren
+# Controls the indent of a BOOL operator when inside a paren. If TRUE, aligns 
+# under the open paren
 indent_bool_paren                         = false    # false/true
 
-# If 'indent_bool_paren' is true, controls the indent of the first expression. If TRUE, aligns the first expression to the following ones
+# If 'indent_bool_paren' is true, controls the indent of the first expression. If TRUE, 
+# aligns the first expression to the following ones
 indent_first_bool_expr                    = false    # false/true
 
-# If an open square is followed by a newline, indent the next line so that it lines up after the open square (not recommended)
+# If an open square is followed by a newline, indent the next line so that it lines up 
+# after the open square (not recommended)
 indent_square_nl                          = false    # false/true
 
 # Don't change the relative indent of ESQL/C 'EXEC SQL' bodies
@@ -261,36 +275,54 @@ indent_oc_msg_colon                       = 0        # number
 # Default is true.
 indent_oc_msg_prioritize_first_colon      = true     # false/true
 
-# If indent_oc_block_msg and this option are on, blocks will be indented the way that Xcode does by default (from keyword if the parameter is on its own line; otherwise, from the previous indentation level).
+# If indent_oc_block_msg and this option are on, blocks will be indented the way that 
+# Xcode does by default (from keyword if the parameter is on its own line; otherwise, 
+# from the previous indentation level).
 indent_oc_block_msg_xcode_style           = false    # false/true
 
-# If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg keyword.
+# If indent_oc_block_msg and this option are on, blocks will be indented from where 
+# the brace is relative to a msg keyword.
 indent_oc_block_msg_from_keyword          = false    # false/true
 
-# If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg colon.
+# If indent_oc_block_msg and this option are on, blocks will be indented from where 
+# the brace is relative to a msg colon.
 indent_oc_block_msg_from_colon            = false    # false/true
 
-# If indent_oc_block_msg and this option are on, blocks will be indented from where the block caret is.
+# If indent_oc_block_msg and this option are on, blocks will be indented from where 
+# the block caret is.
 indent_oc_block_msg_from_caret            = false    # false/true
 
-# If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is.
+# If indent_oc_block_msg and this option are on, blocks will be indented from where 
+# the brace is.
 indent_oc_block_msg_from_brace            = false    # false/true
 
-# When identing after virtual brace open and newline add further spaces to reach this min. indent.
-indent_min_vbrace_open                    = 0        # number
 
-# TRUE: When identing after virtual brace open and newline add further spaces after regular indent to reach next tabstop.
-indent_vbrace_open_on_tabstop             = false    # false/true
 
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
 # Spacing options
-#
+# ####################################################################################################
 
 # Add or remove space around arithmetic operator '+', '-', '/', '*', etc
-sp_arith                                  = ignore   # ignore/add/remove/force
+sp_arith                                  = add   # ignore/add/remove/force
 
 # Add or remove space around assignment operator '=', '+=', etc
-sp_assign                                 = ignore   # ignore/add/remove/force
+sp_assign                                 = add   # ignore/add/remove/force
 
 # Add or remove space around '=' in C++11 lambda capture specifications. Overrides sp_assign
 sp_cpp_lambda_assign                      = ignore   # ignore/add/remove/force
@@ -322,23 +354,24 @@ sp_enum_after_assign                      = ignore   # ignore/add/remove/force
 # Add or remove space around preprocessor '##' concatenation operator. Default=Add
 sp_pp_concat                              = add      # ignore/add/remove/force
 
-# Add or remove space after preprocessor '#' stringify operator. Also affects the '#@' charizing operator.
+# Add or remove space after preprocessor '#' stringify operator. Also affects the '#@' 
+# charizing operator.
 sp_pp_stringify                           = ignore   # ignore/add/remove/force
 
 # Add or remove space before preprocessor '#' stringify operator as in '#define x(y) L#y'.
 sp_before_pp_stringify                    = ignore   # ignore/add/remove/force
 
 # Add or remove space around boolean operators '&&' and '||'
-sp_bool                                   = ignore   # ignore/add/remove/force
+sp_bool                                   = add   # ignore/add/remove/force
 
 # Add or remove space around compare operator '<', '>', '==', etc
-sp_compare                                = ignore   # ignore/add/remove/force
+sp_compare                                = add   # ignore/add/remove/force
 
 # Add or remove space inside '(' and ')'
-sp_inside_paren                           = ignore   # ignore/add/remove/force
+sp_inside_paren                           = add   # ignore/add/remove/force
 
 # Add or remove space between nested parens: '((' vs ') )'
-sp_paren_paren                            = ignore   # ignore/add/remove/force
+sp_paren_paren                            = add   # ignore/add/remove/force
 
 # Add or remove space between back-to-back parens: ')(' vs ') ('
 sp_cparen_oparen                          = ignore   # ignore/add/remove/force
@@ -347,7 +380,7 @@ sp_cparen_oparen                          = ignore   # ignore/add/remove/force
 sp_balance_nested_parens                  = false    # false/true
 
 # Add or remove space between ')' and '{'
-sp_paren_brace                            = ignore   # ignore/add/remove/force
+sp_paren_brace                            = add   # ignore/add/remove/force
 
 # Add or remove space before pointer star '*'
 sp_before_ptr_star                        = ignore   # ignore/add/remove/force
@@ -375,7 +408,7 @@ sp_ptr_star_paren                         = ignore   # ignore/add/remove/force
 sp_before_ptr_star_func                   = ignore   # ignore/add/remove/force
 
 # Add or remove space before a reference sign '&'
-sp_before_byref                           = ignore   # ignore/add/remove/force
+sp_before_byref                           = add   # ignore/add/remove/force
 
 # Add or remove space before a reference sign '&' that isn't followed by a variable name
 # If set to 'ignore', sp_before_byref is used instead.
@@ -391,7 +424,7 @@ sp_after_byref_func                       = ignore   # ignore/add/remove/force
 sp_before_byref_func                      = ignore   # ignore/add/remove/force
 
 # Add or remove space between type and word. Default=Force
-sp_after_type                             = force    # ignore/add/remove/force
+sp_after_type                             = add    # ignore/add/remove/force
 
 # Add or remove space before the paren in the D constructs 'template Foo(' and 'class Foo('.
 sp_before_template_paren                  = ignore   # ignore/add/remove/force
@@ -422,23 +455,23 @@ sp_angle_shift                            = add      # ignore/add/remove/force
 # sp_angle_shift cannot remove the space without this option.
 sp_permit_cpp11_shift                     = false    # false/true
 
-# Add or remove space before '(' of 'if', 'for', 'switch', 'while', etc.
-sp_before_sparen                          = ignore   # ignore/add/remove/force
+# Add or remove space before '(' of 'if', 'for', 'switch', and 'while'
+sp_before_sparen                          = remove   # ignore/add/remove/force
 
 # Add or remove space inside if-condition '(' and ')'
-sp_inside_sparen                          = ignore   # ignore/add/remove/force
+sp_inside_sparen                          = add   # ignore/add/remove/force
 
 # Add or remove space before if-condition ')'. Overrides sp_inside_sparen.
 sp_inside_sparen_close                    = ignore   # ignore/add/remove/force
 
-# Add or remove space after if-condition '('. Overrides sp_inside_sparen.
+# Add or remove space before if-condition '('. Overrides sp_inside_sparen.
 sp_inside_sparen_open                     = ignore   # ignore/add/remove/force
 
 # Add or remove space after ')' of 'if', 'for', 'switch', and 'while'
-sp_after_sparen                           = ignore   # ignore/add/remove/force
+sp_after_sparen                           = add   # ignore/add/remove/force
 
 # Add or remove space between ')' and '{' of 'if', 'for', 'switch', and 'while'
-sp_sparen_brace                           = ignore   # ignore/add/remove/force
+sp_sparen_brace                           = add   # ignore/add/remove/force
 
 # Add or remove space between 'invariant' and '(' in the D language.
 sp_invariant_paren                        = ignore   # ignore/add/remove/force
@@ -447,52 +480,45 @@ sp_invariant_paren                        = ignore   # ignore/add/remove/force
 sp_after_invariant_paren                  = ignore   # ignore/add/remove/force
 
 # Add or remove space before empty statement ';' on 'if', 'for' and 'while'
+# example "while (*p++ = ' ') ;"
 sp_special_semi                           = ignore   # ignore/add/remove/force
 
 # Add or remove space before ';'. Default=Remove
 sp_before_semi                            = remove   # ignore/add/remove/force
 
 # Add or remove space before ';' in non-empty 'for' statements
-sp_before_semi_for                        = ignore   # ignore/add/remove/force
+sp_before_semi_for                        = remove   # ignore/add/remove/force
 
 # Add or remove space before a semicolon of an empty part of a for statement.
-sp_before_semi_for_empty                  = ignore   # ignore/add/remove/force
+sp_before_semi_for_empty                  = add   # ignore/add/remove/force
 
 # Add or remove space after ';', except when followed by a comment. Default=Add
 sp_after_semi                             = add      # ignore/add/remove/force
 
 # Add or remove space after ';' in non-empty 'for' statements. Default=Force
-sp_after_semi_for                         = force    # ignore/add/remove/force
+sp_after_semi_for                         = add    # ignore/add/remove/force
 
-# Add or remove space after the final semicolon of an empty part of a for statement: for ( ; ; <here> ).
-sp_after_semi_for_empty                   = ignore   # ignore/add/remove/force
+# Add or remove space after the final semicolon of an empty part of a for statement: 
+# for ( ; ; <here> ).
+sp_after_semi_for_empty                   = add   # ignore/add/remove/force
 
 # Add or remove space before '[' (except '[]')
 sp_before_square                          = ignore   # ignore/add/remove/force
 
-# Add or remove space before '[]'
+# Add or remove space before '[]', as in 'byte []'
 sp_before_squares                         = ignore   # ignore/add/remove/force
 
 # Add or remove space inside a non-empty '[' and ']'
-sp_inside_square                          = ignore   # ignore/add/remove/force
+sp_inside_square                          = add   # ignore/add/remove/force
 
 # Add or remove space after ','
-sp_after_comma                            = ignore   # ignore/add/remove/force
+sp_after_comma                            = add   # ignore/add/remove/force
 
 # Add or remove space before ','
 sp_before_comma                           = remove   # ignore/add/remove/force
 
-# Add or remove space between ',' and ']' in multidimensional array type 'int[,,]'
-sp_after_mdatype_commas                   = ignore   # ignore/add/remove/force
-
-# Add or remove space between '[' and ',' in multidimensional array type 'int[,,]'
-sp_before_mdatype_commas                  = ignore   # ignore/add/remove/force
-
-# Add or remove space between ',' in multidimensional array type 'int[,,]'
-sp_between_mdatype_commas                 = ignore   # ignore/add/remove/force
-
 # Add or remove space between an open paren and comma: '(,' vs '( ,'
-sp_paren_comma                            = force    # ignore/add/remove/force
+sp_paren_comma                            = add    # ignore/add/remove/force
 
 # Add or remove space before the variadic '...' when preceded by a non-punctuator
 sp_before_ellipsis                        = ignore   # ignore/add/remove/force
@@ -515,51 +541,54 @@ sp_before_case_colon                      = remove   # ignore/add/remove/force
 # Add or remove space between 'operator' and operator sign
 sp_after_operator                         = ignore   # ignore/add/remove/force
 
-# Add or remove space between the operator symbol and the open paren, as in 'operator ++('
+# Add or remove space between the operator symbol and the open paren, as in 
+# 'operator ++('
 sp_after_operator_sym                     = ignore   # ignore/add/remove/force
 
-# Add or remove space after C/D cast, i.e. 'cast(int)a' vs 'cast(int) a' or '(int)a' vs '(int) a'
-sp_after_cast                             = ignore   # ignore/add/remove/force
+# Add or remove space after C/D cast, i.e. 'cast(int)a' vs 'cast(int) a' or '(int)a' vs 
+# '(int) a'
+sp_after_cast                             = add   # ignore/add/remove/force
 
 # Add or remove spaces inside cast parens
 sp_inside_paren_cast                      = ignore   # ignore/add/remove/force
 
-# Add or remove space between the type and open paren in a C++ cast, i.e. 'int(exp)' vs 'int (exp)'
+# Add or remove space between the type and open paren in a C++ cast, i.e. 'int(exp)' 
+# vs 'int (exp)'
 sp_cpp_cast_paren                         = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'sizeof' and '('
-sp_sizeof_paren                           = ignore   # ignore/add/remove/force
+sp_sizeof_paren                           = remove   # ignore/add/remove/force
 
 # Add or remove space after the tag keyword (Pawn)
 sp_after_tag                              = ignore   # ignore/add/remove/force
 
 # Add or remove space inside enum '{' and '}'
-sp_inside_braces_enum                     = ignore   # ignore/add/remove/force
+sp_inside_braces_enum                     = add   # ignore/add/remove/force
 
 # Add or remove space inside struct/union '{' and '}'
-sp_inside_braces_struct                   = ignore   # ignore/add/remove/force
+sp_inside_braces_struct                   = add   # ignore/add/remove/force
 
 # Add or remove space inside '{' and '}'
-sp_inside_braces                          = ignore   # ignore/add/remove/force
+sp_inside_braces                          = add   # ignore/add/remove/force
 
 # Add or remove space inside '{}'
 sp_inside_braces_empty                    = ignore   # ignore/add/remove/force
 
 # Add or remove space between return type and function name
 # A minimum of 1 is forced except for pointer return types.
-sp_type_func                              = ignore   # ignore/add/remove/force
+sp_type_func                              = add   # ignore/add/remove/force
 
 # Add or remove space between function name and '(' on function declaration
-sp_func_proto_paren                       = ignore   # ignore/add/remove/force
+sp_func_proto_paren                       = remove   # ignore/add/remove/force
 
 # Add or remove space between function name and '(' on function definition
-sp_func_def_paren                         = ignore   # ignore/add/remove/force
+sp_func_def_paren                         = remove   # ignore/add/remove/force
 
 # Add or remove space inside empty function '()'
-sp_inside_fparens                         = ignore   # ignore/add/remove/force
+sp_inside_fparens                         = remove   # ignore/add/remove/force
 
 # Add or remove space inside function '(' and ')'
-sp_inside_fparen                          = ignore   # ignore/add/remove/force
+sp_inside_fparen                          = add   # ignore/add/remove/force
 
 # Add or remove space inside the first parens in the function type: 'void (*x)(...)'
 sp_inside_tparen                          = ignore   # ignore/add/remove/force
@@ -568,30 +597,33 @@ sp_inside_tparen                          = ignore   # ignore/add/remove/force
 sp_after_tparen_close                     = ignore   # ignore/add/remove/force
 
 # Add or remove space between ']' and '(' when part of a function call.
+# native yark[rect](a[rect])
 sp_square_fparen                          = ignore   # ignore/add/remove/force
 
 # Add or remove space between ')' and '{' of function
-sp_fparen_brace                           = ignore   # ignore/add/remove/force
+sp_fparen_brace                           = add   # ignore/add/remove/force
 
 # Java: Add or remove space between ')' and '{{' of double brace initializer.
 sp_fparen_dbrace                          = ignore   # ignore/add/remove/force
 
 # Add or remove space between function name and '(' on function calls
-sp_func_call_paren                        = ignore   # ignore/add/remove/force
+sp_func_call_paren                        = remove   # ignore/add/remove/force
 
-# Add or remove space between function name and '()' on function calls without parameters.
+# Add or remove space between function name and '()' on function calls without 
+# parameters.
 # If set to 'ignore' (the default), sp_func_call_paren is used.
 sp_func_call_paren_empty                  = ignore   # ignore/add/remove/force
 
 # Add or remove space between the user function name and '(' on function calls
-# You need to set a keyword to be a user function, like this: 'set func_call_user _' in the config file.
+# You need to set a keyword to be a user function, like this: 'set func_call_user _' 
+# in the config file.
 sp_func_call_user_paren                   = ignore   # ignore/add/remove/force
 
 # Add or remove space between a constructor/destructor and the open paren
-sp_func_class_paren                       = ignore   # ignore/add/remove/force
+sp_func_class_paren                       = remove   # ignore/add/remove/force
 
 # Add or remove space between 'return' and '('
-sp_return_paren                           = ignore   # ignore/add/remove/force
+sp_return_paren                           = add   # ignore/add/remove/force
 
 # Add or remove space between '__attribute__' and '('
 sp_attribute_paren                        = ignore   # ignore/add/remove/force
@@ -617,11 +649,11 @@ sp_version_paren                          = ignore   # ignore/add/remove/force
 # If set to ignore, sp_before_sparen is used.
 sp_scope_paren                            = ignore   # ignore/add/remove/force
 
-# Add or remove space between macro and value
-sp_macro                                  = ignore   # ignore/add/remove/force
+# Add or remove space between macro and value, ie '#define a 6'
+sp_macro                                  = add   # ignore/add/remove/force
 
 # Add or remove space between macro function ')' and value
-sp_macro_func                             = ignore   # ignore/add/remove/force
+sp_macro_func                             = add   # ignore/add/remove/force
 
 # Add or remove space between 'else' and '{' if on the same line
 sp_else_brace                             = ignore   # ignore/add/remove/force
@@ -773,7 +805,8 @@ sp_cond_question_before                   = ignore   # ignore/add/remove/force
 # Add or remove space after the '?' in 'b ? t : f'. Overrides sp_cond_question.
 sp_cond_question_after                    = ignore   # ignore/add/remove/force
 
-# In the abbreviated ternary form (a ?: b), add/remove space between ? and :.'. Overrides all other sp_cond_* options.
+# In the abbreviated ternary form (a ?: b), add/remove space between ? and :.'. 
+# Overrides all other sp_cond_* options.
 sp_cond_ternary_short                     = ignore   # ignore/add/remove/force
 
 # Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make sense here.
@@ -783,10 +816,10 @@ sp_case_label                             = ignore   # ignore/add/remove/force
 sp_range                                  = ignore   # ignore/add/remove/force
 
 # Control the spacing after ':' in 'for (TYPE VAR : EXPR)' (Java)
-sp_after_for_colon                        = ignore   # ignore/add/remove/force
+sp_after_for_colon                        = add   # ignore/add/remove/force
 
 # Control the spacing before ':' in 'for (TYPE VAR : EXPR)' (Java)
-sp_before_for_colon                       = ignore   # ignore/add/remove/force
+sp_before_for_colon                       = add   # ignore/add/remove/force
 
 # Control the spacing in 'extern (C)' (D)
 sp_extern_paren                           = ignore   # ignore/add/remove/force
@@ -794,17 +827,11 @@ sp_extern_paren                           = ignore   # ignore/add/remove/force
 # Control the space after the opening of a C++ comment '// A' vs '//A'
 sp_cmt_cpp_start                          = ignore   # ignore/add/remove/force
 
-# TRUE: If space is added with sp_cmt_cpp_start, do it after doxygen sequences like '///', '///<', '//!' and '//!<'.
-sp_cmt_cpp_doxygen                        = false    # false/true
-
 # Controls the spaces between #else or #endif and a trailing comment
 sp_endif_cmt                              = ignore   # ignore/add/remove/force
 
 # Controls the spaces after 'new', 'delete', and 'delete[]'
 sp_after_new                              = ignore   # ignore/add/remove/force
-
-# Controls the spaces between new and '(' in 'new()'
-sp_between_new_paren                      = ignore   # ignore/add/remove/force
 
 # Controls the spaces before a trailing or embedded comment
 sp_before_tr_emb_cmt                      = ignore   # ignore/add/remove/force
@@ -815,9 +842,27 @@ sp_num_before_tr_emb_cmt                  = 0        # number
 # Control space between a Java annotation and the open paren.
 sp_annotation_paren                       = ignore   # ignore/add/remove/force
 
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
 # Code alignment (not left column spaces/tabs)
-#
+# ####################################################################################################
 
 # Whether to keep non-indenting tabs
 align_keep_tabs                           = false    # false/true
@@ -826,10 +871,11 @@ align_keep_tabs                           = false    # false/true
 align_with_tabs                           = false    # false/true
 
 # Whether to bump out to the next tab when aligning
+# always align on tabstops
 align_on_tabstop                          = false    # false/true
 
 # Whether to left-align numbers
-align_number_left                         = false    # false/true
+align_number_left                         = true    # false/true
 
 # Whether to keep whitespace not required for alignment.
 align_keep_extra_space                    = false    # false/true
@@ -842,13 +888,15 @@ align_func_params                         = false    # false/true
 align_same_func_call_params               = false    # false/true
 
 # The span for aligning variable definitions (0=don't align)
-align_var_def_span                        = 0        # number
+# align variable defs on variable (span for regular stuff)
+align_var_def_span                        = 1        # number
 
 # How to align the star in variable definitions.
 #  0=Part of the type     'void *   foo;'
 #  1=Part of the variable 'void     *foo;'
 #  2=Dangling             'void    *foo;'
-align_var_def_star_style                  = 0        # number
+# the star is part of the variable name
+align_var_def_star_style                  = 1        # number
 
 # How to align the '&' in variable definitions.
 #  0=Part of the type
@@ -869,22 +917,23 @@ align_var_def_colon                       = false    # false/true
 align_var_def_attribute                   = false    # false/true
 
 # Whether to align inline struct/enum/union variable definitions
-align_var_def_inline                      = false    # false/true
+align_var_def_inline                      = true    # false/true
 
 # The span for aligning on '=' in assignments (0=don't align)
-align_assign_span                         = 0        # number
+align_assign_span                         = 1        # number
 
 # The threshold for aligning on '=' in assignments (0=no limit)
 align_assign_thresh                       = 0        # number
 
 # The span for aligning on '=' in enums (0=don't align)
-align_enum_equ_span                       = 0        # number
+# align the '=' in enums
+align_enum_equ_span                       = 1        # number
 
 # The threshold for aligning on '=' in enums (0=no limit)
 align_enum_equ_thresh                     = 0        # number
 
 # The span for aligning struct/union (0=don't align)
-align_var_struct_span                     = 0        # number
+align_var_struct_span                     = 1        # number
 
 # The threshold for aligning struct/union member definitions (0=no limit)
 align_var_struct_thresh                   = 0        # number
@@ -893,13 +942,13 @@ align_var_struct_thresh                   = 0        # number
 align_var_struct_gap                      = 0        # number
 
 # The span for aligning struct initializer values (0=don't align)
-align_struct_init_span                    = 0        # number
+align_struct_init_span                    = 1        # number
 
 # The minimum space between the type and the synonym of a typedef
-align_typedef_gap                         = 0        # number
+align_typedef_gap                         = 1        # number
 
 # The span for aligning single-line typedefs (0=don't align)
-align_typedef_span                        = 0        # number
+align_typedef_span                        = 1        # number
 
 # How to align typedef'd functions with other typedefs
 # 0: Don't mix them at all
@@ -911,7 +960,7 @@ align_typedef_func                        = 0        # number
 # 0: Align on typedef type, ignore '*'
 # 1: The '*' is part of type name: typedef int  *pint;
 # 2: The '*' is part of the type, but dangling: typedef int *pint;
-align_typedef_star_style                  = 0        # number
+align_typedef_star_style                  = 1        # number
 
 # Controls the positioning of the '&' in typedefs. Just try it.
 # 0: Align on typedef type, ignore '&'
@@ -922,18 +971,20 @@ align_typedef_amp_style                   = 0        # number
 # The span for aligning comments that end lines (0=don't align)
 align_right_cmt_span                      = 0        # number
 
-# If aligning comments, mix with comments after '}' and #endif with less than 3 spaces before the comment
+# If aligning comments, mix with comments after '}' and #endif with less than 3 
+# spaces before the comment
 align_right_cmt_mix                       = false    # false/true
 
-# If a trailing comment is more than this number of columns away from the text it follows,
-# it will qualify for being aligned. This has to be > 0 to do anything.
+# If a trailing comment is more than this number of columns away from the text it 
+# follows, it will qualify for being aligned. This has to be > 0 to do anything.
 align_right_cmt_gap                       = 0        # number
 
-# Align trailing comment at or beyond column N; 'pulls in' comments as a bonus side effect (0=ignore)
+# Align trailing comment at or beyond column N; 'pulls in' comments as a bonus 
+# side effect (0=ignore)
 align_right_cmt_at_col                    = 0        # number
 
 # The span for aligning function prototypes (0=don't align)
-align_func_proto_span                     = 0        # number
+align_func_proto_span                     = 1        # number
 
 # Minimum gap between the return type and the function name.
 align_func_proto_gap                      = 0        # number
@@ -942,7 +993,8 @@ align_func_proto_gap                      = 0        # number
 align_on_operator                         = false    # false/true
 
 # Whether to mix aligning prototype and variable declarations.
-# If true, align_var_def_XXX options are used instead of align_func_proto_XXX options.
+# If true, align_var_def_XXX options are used instead of align_func_proto_XXX 
+# options.
 align_mix_var_proto                       = false    # false/true
 
 # Align single-line functions with function prototypes, uses align_func_proto_span
@@ -960,16 +1012,19 @@ align_oc_msg_spec_span                    = 0        # number
 
 # Whether to align macros wrapped with a backslash and a newline.
 # This will not work right if the macro contains a multi-line comment.
+# align the back-slash \n combo (macros)
 align_nl_cont                             = false    # false/true
 
 # # Align macro functions and variables together
 align_pp_define_together                  = false    # false/true
 
 # The minimum space between label and value of a preprocessor define
-align_pp_define_gap                       = 0        # number
+# min space between define label and value "#define a <---> 16"
+align_pp_define_gap                       = 1        # number
 
-# The span for aligning on '#define' bodies (0=don't align, other=number of lines including comments between blocks)
-align_pp_define_span                      = 0        # number
+# The span for aligning on '#define' bodies (0=don't align, other=number of lines 
+# including comments between blocks)
+align_pp_define_span                      = 1        # number
 
 # Align lines that start with '<<' with previous '<<'. Default=true
 align_left_shift                          = true     # false/true
@@ -983,9 +1038,27 @@ align_oc_msg_colon_first                  = false    # false/true
 # Aligning parameters in an Obj-C '+' or '-' declaration on the ':'
 align_oc_decl_colon                       = false    # false/true
 
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
 # Newline adding and removing options
-#
+# ####################################################################################################
 
 # Whether to collapse empty blocks between '{' and '}'
 nl_collapse_empty_body                    = false    # false/true
@@ -1017,14 +1090,16 @@ nl_oc_msg_leave_one_liner                 = false    # false/true
 # Add or remove newlines at the start of the file
 nl_start_of_file                          = ignore   # ignore/add/remove/force
 
-# The number of newlines at the start of the file (only used if nl_start_of_file is 'add' or 'force'
+# The number of newlines at the start of the file (only used if nl_start_of_file is 
+# 'add' or 'force'
 nl_start_of_file_min                      = 0        # number
 
 # Add or remove newline at the end of the file
-nl_end_of_file                            = ignore   # ignore/add/remove/force
+nl_end_of_file                            = add   # ignore/add/remove/force
 
-# The number of newlines at the end of the file (only used if nl_end_of_file is 'add' or 'force')
-nl_end_of_file_min                        = 0        # number
+# The number of newlines at the end of the file (only used if nl_end_of_file is 
+# 'add' or 'force')
+nl_end_of_file_min                        = 2        # number
 
 # Add or remove newline between '=' and '{'
 nl_assign_brace                           = ignore   # ignore/add/remove/force
@@ -1035,7 +1110,8 @@ nl_assign_square                          = ignore   # ignore/add/remove/force
 # Add or remove newline after '= [' (D only). Will also affect the newline before the ']'
 nl_after_square_assign                    = ignore   # ignore/add/remove/force
 
-# The number of blank lines after a block of variable definitions at the top of a function body
+# The number of blank lines after a block of variable definitions at the top of a 
+# function body
 # 0 = No change (default)
 nl_func_var_def_blk                       = 0        # number
 
@@ -1051,11 +1127,13 @@ nl_typedef_blk_end                        = 0        # number
 # 0 = No change (default)
 nl_typedef_blk_in                         = 0        # number
 
-# The number of newlines before a block of variable definitions not at the top of a function body
+# The number of newlines before a block of variable definitions not at the top of 
+# a function body
 # 0 = No change (default)
 nl_var_def_blk_start                      = 0        # number
 
-# The number of newlines after a block of variable definitions not at the top of a function body
+# The number of newlines after a block of variable definitions not at the top of 
+# a function body
 # 0 = No change (default)
 nl_var_def_blk_end                        = 0        # number
 
@@ -1065,7 +1143,7 @@ nl_var_def_blk_in                         = 0        # number
 
 # Add or remove newline between a function call's ')' and '{', as in:
 # list_for_each(item, &list) { }
-nl_fcall_brace                            = ignore   # ignore/add/remove/force
+nl_fcall_brace                            = force   # ignore/add/remove/force
 
 # Add or remove newline between 'enum' and '{'
 nl_enum_brace                             = ignore   # ignore/add/remove/force
@@ -1077,17 +1155,17 @@ nl_struct_brace                           = ignore   # ignore/add/remove/force
 nl_union_brace                            = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'if' and '{'
-nl_if_brace                               = ignore   # ignore/add/remove/force
+nl_if_brace                               = force   # ignore/add/remove/force
 
 # Add or remove newline between '}' and 'else'
-nl_brace_else                             = ignore   # ignore/add/remove/force
+nl_brace_else                             = force   # ignore/add/remove/force
 
 # Add or remove newline between 'else if' and '{'
 # If set to ignore, nl_if_brace is used instead
-nl_elseif_brace                           = ignore   # ignore/add/remove/force
+nl_elseif_brace                           = force   # ignore/add/remove/force
 
 # Add or remove newline between 'else' and '{'
-nl_else_brace                             = ignore   # ignore/add/remove/force
+nl_else_brace                             = force   # ignore/add/remove/force
 
 # Add or remove newline between 'else' and 'if'
 nl_else_if                                = ignore   # ignore/add/remove/force
@@ -1105,7 +1183,7 @@ nl_try_brace                              = ignore   # ignore/add/remove/force
 nl_getset_brace                           = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'for' and '{'
-nl_for_brace                              = ignore   # ignore/add/remove/force
+nl_for_brace                              = force   # ignore/add/remove/force
 
 # Add or remove newline between 'catch' and '{'
 nl_catch_brace                            = ignore   # ignore/add/remove/force
@@ -1120,7 +1198,7 @@ nl_brace_square                           = ignore   # ignore/add/remove/force
 nl_brace_fparen                           = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'while' and '{'
-nl_while_brace                            = ignore   # ignore/add/remove/force
+nl_while_brace                            = force   # ignore/add/remove/force
 
 # Add or remove newline between 'scope (x)' and '{' (D)
 nl_scope_brace                            = ignore   # ignore/add/remove/force
@@ -1139,20 +1217,18 @@ nl_using_brace                            = ignore   # ignore/add/remove/force
 nl_brace_brace                            = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'do' and '{'
-nl_do_brace                               = ignore   # ignore/add/remove/force
+nl_do_brace                               = force   # ignore/add/remove/force
 
 # Add or remove newline between '}' and 'while' of 'do' statement
-nl_brace_while                            = ignore   # ignore/add/remove/force
+nl_brace_while                            = force   # ignore/add/remove/force
 
 # Add or remove newline between 'switch' and '{'
-nl_switch_brace                           = ignore   # ignore/add/remove/force
-
-# Add or remove newline between 'synchronized' and '{'
-nl_synchronized_brace                     = ignore   # ignore/add/remove/force
+nl_switch_brace                           = force   # ignore/add/remove/force
 
 # Add a newline between ')' and '{' if the ')' is on a different line than the if/for/etc.
-# Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch, and nl_catch_brace.
-nl_multi_line_cond                        = false    # false/true
+# Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch, and 
+# nl_catch_brace.
+nl_multi_line_cond                        = true    # false/true
 
 # Force a newline in a define after the macro name for multi-line defines.
 nl_multi_line_define                      = false    # false/true
@@ -1167,7 +1243,7 @@ nl_before_throw                           = ignore   # ignore/add/remove/force
 nl_after_case                             = false    # false/true
 
 # Add or remove a newline between a case ':' and '{'. Overrides nl_after_case.
-nl_case_colon_brace                       = ignore   # ignore/add/remove/force
+nl_case_colon_brace                       = force   # ignore/add/remove/force
 
 # Newline between namespace and {
 nl_namespace_brace                        = ignore   # ignore/add/remove/force
@@ -1223,10 +1299,10 @@ nl_func_decl_args                         = ignore   # ignore/add/remove/force
 nl_func_def_args                          = ignore   # ignore/add/remove/force
 
 # Add or remove newline before the ')' in a function declaration
-nl_func_decl_end                          = ignore   # ignore/add/remove/force
+nl_func_decl_end                          = remove   # ignore/add/remove/force
 
 # Add or remove newline before the ')' in a function definition
-nl_func_def_end                           = ignore   # ignore/add/remove/force
+nl_func_def_end                           = remove   # ignore/add/remove/force
 
 # Overrides nl_func_decl_end when there is only one parameter.
 nl_func_decl_end_single                   = ignore   # ignore/add/remove/force
@@ -1245,7 +1321,8 @@ nl_func_def_empty                         = ignore   # ignore/add/remove/force
 nl_oc_msg_args                            = false    # false/true
 
 # Add or remove newline between function signature and '{'
-nl_fdef_brace                             = ignore   # ignore/add/remove/force
+# "int foo() {" vs "int foo()\n{"
+nl_fdef_brace                             = force   # ignore/add/remove/force
 
 # Add or remove newline between C++11 lambda signature and '{'
 nl_cpp_ldef_brace                         = ignore   # ignore/add/remove/force
@@ -1281,7 +1358,7 @@ nl_after_brace_close                      = false    # false/true
 
 # Whether to put a newline after a virtual brace close.
 # Would add a newline before return in: 'if (foo) a++; return;'
-nl_after_vbrace_close                     = false    # false/true
+nl_after_vbrace_close                     = true    # false/true
 
 # Control the newline between the close brace and 'b' in: 'struct { int a; } b;'
 # Affects enums, unions, and structures. If set to ignore, uses nl_after_brace_close
@@ -1290,41 +1367,36 @@ nl_brace_struct_var                       = ignore   # ignore/add/remove/force
 # Whether to alter newlines in '#define' macros
 nl_define_macro                           = false    # false/true
 
-# Whether to not put blanks after '#ifxx', '#elxx', or before '#endif'. Does not affect the whole-file #ifdef.
-nl_squeeze_ifdef                          = false    # false/true
+# Whether to not put blanks after '#ifxx', '#elxx', or before '#endif'
+# No blanks after #ifxx, #elxx, or before #endif TRUE/F
+nl_squeeze_ifdef                          = true    # false/true
 
 # Add or remove blank line before 'if'
-nl_before_if                              = ignore   # ignore/add/remove/force
+nl_before_if                              = force   # ignore/add/remove/force
 
 # Add or remove blank line after 'if' statement
 nl_after_if                               = ignore   # ignore/add/remove/force
 
 # Add or remove blank line before 'for'
-nl_before_for                             = ignore   # ignore/add/remove/force
+nl_before_for                             = force   # ignore/add/remove/force
 
 # Add or remove blank line after 'for' statement
 nl_after_for                              = ignore   # ignore/add/remove/force
 
 # Add or remove blank line before 'while'
-nl_before_while                           = ignore   # ignore/add/remove/force
+nl_before_while                           = force   # ignore/add/remove/force
 
 # Add or remove blank line after 'while' statement
 nl_after_while                            = ignore   # ignore/add/remove/force
 
 # Add or remove blank line before 'switch'
-nl_before_switch                          = ignore   # ignore/add/remove/force
+nl_before_switch                          = force   # ignore/add/remove/force
 
 # Add or remove blank line after 'switch' statement
 nl_after_switch                           = ignore   # ignore/add/remove/force
 
-# Add or remove blank line before 'synchronized'
-nl_before_synchronized                    = ignore   # ignore/add/remove/force
-
-# Add or remove blank line after 'synchronized' statement
-nl_after_synchronized                     = ignore   # ignore/add/remove/force
-
 # Add or remove blank line before 'do'
-nl_before_do                              = ignore   # ignore/add/remove/force
+nl_before_do                              = force   # ignore/add/remove/force
 
 # Add or remove blank line after 'do/while' statement
 nl_after_do                               = ignore   # ignore/add/remove/force
@@ -1356,50 +1428,97 @@ nl_create_for_one_liner                   = false    # false/true
 # 'while (i<5)\n foo(i++);' => 'while (i<5) foo(i++);'
 nl_create_while_one_liner                 = false    # false/true
 
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
 # Positioning options
-#
+# ####################################################################################################
 
 # The position of arithmetic operators in wrapped expressions
-pos_arith                                 = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_arith                                 = ignore   
 
 # The position of assignment in wrapped expressions.
 # Do not affect '=' followed by '{'
-pos_assign                                = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_assign                                = ignore   
 
 # The position of boolean operators in wrapped expressions
-pos_bool                                  = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+# end=move &&/|| to EOL ignore=gnore, start=move to SOL
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_bool                                  = lead_force   
 
 # The position of comparison operators in wrapped expressions
-pos_compare                               = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_compare                               = ignore   
 
 # The position of conditional (b ? t : f) operators in wrapped expressions
-pos_conditional                           = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_conditional                           = ignore   
 
 # The position of the comma in wrapped expressions
-pos_comma                                 = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_comma                                 = ignore   
 
 # The position of the comma in the class base list
-pos_class_comma                           = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_class_comma                           = ignore   
 
 # The position of the comma in the constructor initialization list
-pos_constr_comma                          = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_constr_comma                          = ignore   
 
 # The position of colons between class and base class list
-pos_class_colon                           = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_class_colon                           = ignore   
 
 # The position of colons between constructor and member initialization
-pos_constr_colon                          = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+# ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+pos_constr_colon                          = ignore   
 
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
 # Line Splitting options
-#
+# ####################################################################################################
 
 # Try to limit code width to N number of columns
 code_width                                = 0        # number
 
 # Whether to fully split long 'for' statements at semi-colons
-ls_for_split_full                         = false    # false/true
+ls_for_split_full                         = true    # false/true
 
 # Whether to fully split long function protos/calls at commas
 ls_func_split_full                        = false    # false/true
@@ -1407,21 +1526,42 @@ ls_func_split_full                        = false    # false/true
 # Whether to split lines as close to code_width as possible and ignore some groupings
 ls_code_width                             = false    # false/true
 
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
 # Blank line options
-#
+# ####################################################################################################
 
 # The maximum consecutive newlines
-nl_max                                    = 0        # number
+# Maximum consecutive newlines, 3=2 lines, 0=disabled
+nl_max                                    = 3        # number
 
-# The number of newlines after a function prototype, if followed by another function prototype
-nl_after_func_proto                       = 0        # number
+# The number of newlines after a function prototype, if followed by another 
+# function prototype
+nl_after_func_proto                       = 3        # number
 
-# The number of newlines after a function prototype, if not followed by another function prototype
-nl_after_func_proto_group                 = 0        # number
+# The number of newlines after a function prototype, if not followed by another 
+# function prototype
+nl_after_func_proto_group                 = 3        # number
 
 # The number of newlines after '}' of a multi-line function body
-nl_after_func_body                        = 0        # number
+nl_after_func_body                        = 2        # number
 
 # The number of newlines after '}' of a multi-line function body in a class declaration
 nl_after_func_body_class                  = 0        # number
@@ -1431,7 +1571,8 @@ nl_after_func_body_one_liner              = 0        # number
 
 # The minimum number of newlines before a multi-line comment.
 # Doesn't apply if after a brace open or another multi-line comment.
-nl_before_block_comment                   = 0        # number
+# Before a block comment (stand-alone comment-multi), except after brace open
+nl_before_block_comment                   = 3        # number
 
 # The minimum number of newlines before a single-line C comment.
 # Doesn't apply if after a brace open or other single-line C comments.
@@ -1443,9 +1584,6 @@ nl_before_cpp_comment                     = 0        # number
 
 # Whether to force a newline after a multi-line comment.
 nl_after_multiline_comment                = false    # false/true
-
-# Whether to force a newline after a label's colon.
-nl_after_label_colon                      = false    # false/true
 
 # The number of newlines after '}' or ';' of a struct/enum/union definition
 nl_after_struct                           = 0        # number
@@ -1482,10 +1620,10 @@ nl_between_get_set                        = 0        # number
 nl_property_brace                         = ignore   # ignore/add/remove/force
 
 # Whether to remove blank lines after '{'
-eat_blanks_after_open_brace               = false    # false/true
+eat_blanks_after_open_brace               = true    # false/true
 
 # Whether to remove blank lines before '}'
-eat_blanks_before_close_brace             = false    # false/true
+eat_blanks_before_close_brace             = true    # false/true
 
 # How aggressively to remove extra newlines not in preproc.
 # 0: No change
@@ -1506,31 +1644,52 @@ nl_after_annotation                       = ignore   # ignore/add/remove/force
 # Controls the newline between two annotations.
 nl_between_annotation                     = ignore   # ignore/add/remove/force
 
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
 # Code modifying options (non-whitespace)
-#
+# ####################################################################################################
 
 # Add or remove braces on single-line 'do' statement
-mod_full_brace_do                         = ignore   # ignore/add/remove/force
+mod_full_brace_do                         = force   # ignore/add/remove/force
 
 # Add or remove braces on single-line 'for' statement
-mod_full_brace_for                        = ignore   # ignore/add/remove/force
+mod_full_brace_for                        = force   # ignore/add/remove/force
 
 # Add or remove braces on single-line function definitions. (Pawn)
-mod_full_brace_function                   = ignore   # ignore/add/remove/force
+mod_full_brace_function                   = force   # ignore/add/remove/force
 
-# Add or remove braces on single-line 'if' statement. Will not remove the braces if they contain an 'else'.
-mod_full_brace_if                         = ignore   # ignore/add/remove/force
+# Add or remove braces on single-line 'if' statement. Will not remove the braces 
+# if they contain an 'else'.
+mod_full_brace_if                         = force   # ignore/add/remove/force
 
-# Make all if/elseif/else statements in a chain be braced or not. Overrides mod_full_brace_if.
-# If any must be braced, they are all braced.  If all can be unbraced, then the braces are removed.
+# Make all if/elseif/else statements in a chain be braced or not. Overrides 
+# mod_full_brace_if. # If any must be braced, they are all braced.  If all can be 
+# unbraced, then the braces are removed.
 mod_full_brace_if_chain                   = false    # false/true
 
 # Don't remove braces around statements that span N newlines
-mod_full_brace_nl                         = 0        # number
+# Max number of newlines to span w/o braces
+mod_full_brace_nl                         = 1        # number
 
 # Add or remove braces on single-line 'while' statement
-mod_full_brace_while                      = ignore   # ignore/add/remove/force
+mod_full_brace_while                      = force   # ignore/add/remove/force
 
 # Add or remove braces on single-line 'using ()' statement
 mod_full_brace_using                      = ignore   # ignore/add/remove/force
@@ -1547,23 +1706,28 @@ mod_full_paren_if_bool                    = false    # false/true
 # Whether to remove superfluous semicolons
 mod_remove_extra_semicolon                = false    # false/true
 
-# If a function body exceeds the specified number of newlines and doesn't have a comment after
+# If a function body exceeds the specified number of newlines and doesn't have a 
+# comment after
 # the close brace, a comment will be added.
 mod_add_long_function_closebrace_comment  = 0        # number
 
-# If a namespace body exceeds the specified number of newlines and doesn't have a comment after
+# If a namespace body exceeds the specified number of newlines and doesn't have 
+# a comment after
 # the close brace, a comment will be added.
 mod_add_long_namespace_closebrace_comment = 0        # number
 
-# If a switch body exceeds the specified number of newlines and doesn't have a comment after
+# If a switch body exceeds the specified number of newlines and doesn't have a 
+# comment after
 # the close brace, a comment will be added.
 mod_add_long_switch_closebrace_comment    = 0        # number
 
-# If an #ifdef body exceeds the specified number of newlines and doesn't have a comment after
+# If an #ifdef body exceeds the specified number of newlines and doesn't have a 
+# comment after
 # the #endif, a comment will be added.
 mod_add_long_ifdef_endif_comment          = 0        # number
 
-# If an #ifdef or #else body exceeds the specified number of newlines and doesn't have a comment after
+# If an #ifdef or #else body exceeds the specified number of newlines and doesn't 
+# have a comment after
 # the #else, a comment will be added.
 mod_add_long_ifdef_else_comment           = 0        # number
 
@@ -1573,11 +1737,13 @@ mod_sort_import                           = false    # false/true
 # If TRUE, will sort consecutive single-line 'using' statements [C#]
 mod_sort_using                            = false    # false/true
 
-# If TRUE, will sort consecutive single-line '#include' statements [C/C++] and '#import' statements [Obj-C]
+# If TRUE, will sort consecutive single-line '#include' statements [C/C++] and 
+# '#import' statements [Obj-C]
 # This is generally a bad idea, as it may break your code.
 mod_sort_include                          = false    # false/true
 
-# If TRUE, it will move a 'break' that appears after a fully braced 'case' before the close brace.
+# If TRUE, it will move a 'break' that appears after a fully braced 'case' before the 
+# close brace.
 mod_move_case_break                       = false    # false/true
 
 # Will add or remove the braces around a fully braced case statement.
@@ -1587,9 +1753,27 @@ mod_case_brace                            = ignore   # ignore/add/remove/force
 # If TRUE, it will remove a void 'return;' that appears as the last statement in a function.
 mod_remove_empty_return                   = false    # false/true
 
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
 # Comment modifications
-#
+# ####################################################################################################
 
 # Try to wrap comments at cmt_width columns
 cmt_width                                 = 0        # number
@@ -1600,12 +1784,14 @@ cmt_width                                 = 0        # number
 # 2: full reflow
 cmt_reflow_mode                           = 0        # number
 
-# Whether to convert all tabs to spaces in comments. Default is to leave tabs inside comments alone, unless used for indenting.
-cmt_convert_tab_to_spaces                 = false    # false/true
+# Whether to convert all tabs to spaces in comments. Default is to leave tabs inside 
+# comments alone, unless used for indenting.
+cmt_convert_tab_to_spaces                 = true    # false/true
 
-# If false, disable all multi-line comment changes, including cmt_width. keyword substitution, and leading chars.
+# If false, disable all multi-line comment changes, including cmt_width. keyword 
+# substitution, and leading chars.
 # Default is true.
-cmt_indent_multi                          = true     # false/true
+cmt_indent_multi                          = false     # false/true
 
 # Whether to group c-comments that look like they are in a block
 cmt_c_group                               = false    # false/true
@@ -1617,9 +1803,11 @@ cmt_c_nl_start                            = false    # false/true
 cmt_c_nl_end                              = false    # false/true
 
 # Whether to group cpp-comments that look like they are in a block
+# If UO_cmt_cpp_to_c, try to group in one big C comment
 cmt_cpp_group                             = false    # false/true
 
 # Whether to put an empty '/*' on the first line of the combined cpp-comment
+# Put a blank /* at the start of a converted group
 cmt_cpp_nl_start                          = false    # false/true
 
 # Whether to put a newline before the closing '*/' of the combined cpp-comment
@@ -1637,29 +1825,37 @@ cmt_sp_before_star_cont                   = 0        # number
 # The number of spaces to insert after the star on subsequent comment lines
 cmt_sp_after_star_cont                    = 0        # number
 
-# For multi-line comments with a '*' lead, remove leading spaces if the first and last lines of
+# For multi-line comments with a '*' lead, remove leading spaces if the first and 
+# last lines of
 # the comment are the same length. Default=True
 cmt_multi_check_last                      = true     # false/true
 
-# The filename that contains text to insert at the head of a file if the file doesn't start with a C/C++ comment.
+# The filename that contains text to insert at the head of a file if the file doesn't 
+# start with a C/C++ comment.
 # Will substitute $(filename) with the current file's name.
 cmt_insert_file_header                    = ""         # string
 
-# The filename that contains text to insert at the end of a file if the file doesn't end with a C/C++ comment.
+# The filename that contains text to insert at the end of a file if the file doesn't end 
+# with a C/C++ comment.
 # Will substitute $(filename) with the current file's name.
 cmt_insert_file_footer                    = ""         # string
 
-# The filename that contains text to insert before a function implementation if the function isn't preceded with a C/C++ comment.
-# Will substitute $(function) with the function name and $(javaparam) with the javadoc @param and @return stuff.
+# The filename that contains text to insert before a function implementation if the 
+# function isn't preceded with a C/C++ comment.
+# Will substitute $(function) with the function name and $(javaparam) with the 
+# javadoc @param and @return stuff.
 # Will also substitute $(fclass) with the class name: void CFoo::Bar() { ... }
 cmt_insert_func_header                    = ""         # string
 
-# The filename that contains text to insert before a class if the class isn't preceded with a C/C++ comment.
+# The filename that contains text to insert before a class if the class isn't preceded 
+# with a C/C++ comment.
 # Will substitute $(class) with the class name.
 cmt_insert_class_header                   = ""         # string
 
-# The filename that contains text to insert before a Obj-C message specification if the method isn't preceded with a C/C++ comment.
-# Will substitute $(message) with the function name and $(javaparam) with the javadoc @param and @return stuff.
+# The filename that contains text to insert before a Obj-C message specification if 
+# the method isn't preceded with a C/C++ comment.
+# Will substitute $(message) with the function name and $(javaparam) with the 
+# javadoc @param and @return stuff.
 cmt_insert_oc_msg_header                  = ""         # string
 
 # If a preprocessor is encountered when stepping backwards from a function name, then
@@ -1667,9 +1863,27 @@ cmt_insert_oc_msg_header                  = ""         # string
 # Affects cmt_insert_oc_msg_header, cmt_insert_func_header and cmt_insert_class_header.
 cmt_insert_before_preproc                 = false    # false/true
 
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# ####################################################################################################
 # Preprocessor options
-#
+# ####################################################################################################
 
 # Control indent of preprocessors inside #if blocks at brace level 0 (file-level)
 pp_indent                                 = ignore   # ignore/add/remove/force
@@ -1677,8 +1891,10 @@ pp_indent                                 = ignore   # ignore/add/remove/force
 # Whether to indent #if/#else/#endif at the brace level (true) or from column 1 (false)
 pp_indent_at_level                        = false    # false/true
 
-# Specifies the number of columns to indent preprocessors per level at brace level 0 (file-level).
-# If pp_indent_at_level=false, specifies the number of columns to indent preprocessors per level at brace level > 0 (function-level).
+# Specifies the number of columns to indent preprocessors per level at brace level 
+# 0 (file-level).
+# If pp_indent_at_level=false, specifies the number of columns to indent 
+# preprocessors per level at brace level > 0 (function-level).
 # Default=1.
 pp_indent_count                           = 1        # number
 
@@ -1694,7 +1910,8 @@ pp_indent_region                          = 0        # number
 # Whether to indent the code between #region and #endregion
 pp_region_indent_code                     = false    # false/true
 
-# If pp_indent_at_level=true, sets the indent for #if, #else, and #endif when not at file-level.
+# If pp_indent_at_level=true, sets the indent for #if, #else, and #endif when not at 
+# file-level.
 # 0:  indent preprocessors using output_tab_size.
 # >0: column at which all preprocessors will be indented.
 pp_indent_if                              = 0        # number

--- a/tests/input/pawn/pawn_amxmodx.sma
+++ b/tests/input/pawn/pawn_amxmodx.sma
@@ -1,0 +1,35 @@
+#include <amxmodx>
+
+#define COOL_MACRO( %1 , %2 ) ( %1 + %2 + 1 )
+
+#define SXO( % 1 ,%2) 1 < %1 || %2 > 2
+
+public plugin_init()
+{
+    for( new i = 0; i < 5; i++ )
+    {
+                crazy_var =crazy_var + 5 % (18 *15)/26
+        crazy_var= crazy_var + 5%( 18* 15 ) /  26
+        server_print( "(%i) Test2: %i Test1: %i", i, Test2(), Test1() );
+    }
+    
+    if( SXO( Test2(), Test1() ) )
+    {
+        COOL_MACRO( Test2(), Test1() )
+    }
+}
+
+Test1()
+{
+    static var;
+    var++
+    #emit CONST. pri 1337
+    return var;
+}
+
+Test2()
+{
+    #emit CONST .pri 1911
+    static var;
+    return --var
+}

--- a/tests/output/pawn/60040-pawn_amxmodx.sma
+++ b/tests/output/pawn/60040-pawn_amxmodx.sma
@@ -1,0 +1,37 @@
+#include <amxmodx>
+
+#define COOL_MACRO(%1,%2) ( %1 + %2 + 1 )
+
+#define SXO(%1,%2) 1 < %1 \
+    || %2 > 2
+
+public plugin_init()
+{
+    for( new i = 0; i < 5; i++ )
+    {
+        crazy_var = crazy_var + 5 % ( 18 * 15 ) / 26
+        crazy_var = crazy_var + 5 % ( 18 * 15 ) /  26
+        server_print( "(%i) Test2: %i Test1: %i", i, Test2(), Test1() );
+    }
+
+    if( SXO( Test2(), Test1() ) )
+    {
+        COOL_MACRO( Test2(), Test1() )
+    }
+}
+
+Test1()
+{
+    static var;
+    var++
+    #emit CONST.pri 1337
+    return var;
+}
+
+Test2()
+{
+    #emit CONST.pri 1911
+    static var;
+    return --var
+}
+

--- a/tests/pawn.test
+++ b/tests/pawn.test
@@ -17,3 +17,5 @@
 
 60030 amxmodx.cfg              pawn/crusty_ex-1.sma
 
+60040 pawn_amxmodx.cfg              pawn/pawn_amxmodx.sma
+


### PR DESCRIPTION
Fix issue 414: The actual global spacing options must not to be applicated
to the preprocessor

https://github.com/bengardner/uncrustify/issues/414

This fix is applicable/activated if the ASCII value of the string escape char 94
is selected.

It remove spaces only at the preprocessor macro functions declarations and
ignore adding arithmetic expressions spaces at the macro
function body.
Ex: '#define COOL_MACRO(%1,%2)   ( %1 = %2 + 1 )' # instead of:
'define COOL_MACRO( % 1 , % 2 )   ( % 1 = % 2 + 1 )', which is wrong.

To accomplish it, this overrides sp_inside_paren, sp_after_comma and sp_arith
only at the macro function declaration and body.

This also fix an unreported issue where the "#emit" preprocessor directive was
receiving a space after a DOT.
Ex: '#emit CONST .pri 1911' or '#emit CONST. pri 1911', which is wrong.
instead of: '#emit CONST.pri 1911', the correct one.

Also updated the "amxmodx.cfg" config accordingly with the correct and up-to-date configuration.

Created a test for the newer pawn configuration.
This are the new test results:
Tests: ['c-sharp', 'c', 'cpp', 'd', 'java', 'pawn', 'objective-c', 'vala', 'ecma']
Processing c-sharp.test
Processing c.test
UNSTABLE: 00012
UNSTABLE: 00617
UNSTABLE: 02100
UNSTABLE: 02102
UNSTABLE: 02501
Processing cpp.test
UNSTABLE: 30265
UNSTABLE: 30815
Processing d.test
Processing java.test
Processing pawn.test
Processing objective-c.test
UNSTABLE: 50007
Processing vala.test
Processing ecma.test
Passed 517 / 517 tests
All tests passed, but some files were unstable

This are the tests results before this work:
Tests: ['c-sharp', 'c', 'cpp', 'd', 'java', 'pawn', 'objective-c', 'vala', 'ecma']
Processing c-sharp.test
Processing c.test
UNSTABLE: 00012
UNSTABLE: 00617
UNSTABLE: 02100
UNSTABLE: 02102
UNSTABLE: 02501
Processing cpp.test
UNSTABLE: 30265
UNSTABLE: 30815
Processing d.test
Processing java.test
Processing pawn.test
Processing objective-c.test
UNSTABLE: 50007
Processing vala.test
Processing ecma.test
Passed 516 / 516 tests
All tests passed, but some files were unstable